### PR TITLE
Fix broken dependency message_queue for moonlight-tv

### DIFF
--- a/package/moonlight-tv/moonlight-tv.mk
+++ b/package/moonlight-tv/moonlight-tv.mk
@@ -9,6 +9,11 @@ MOONLIGHT_TV_SITE = https://github.com/mariotaku/moonlight-tv.git
 MOONLIGHT_TV_SITE_METHOD = git
 MOONLIGHT_TV_GIT_SUBMODULES = YES
 
+define MOONLIGHT_TV_PATCH_SUBMODULE
+  git config --global url."https://github.com/GuillaumeSmaha/message_queue".insteadOf "https://github.com/LnxPrgr3/message_queue"
+endef
+MOONLIGHT_TV_PRE_DOWNLOAD_HOOKS += MOONLIGHT_TV_PATCH_SUBMODULE
+
 MOONLIGHT_TV_DEPENDENCIES = \
 	host-pkgconf \
 	libglib2 \


### PR DESCRIPTION
I was able to find the code for the broken dependency on moonlight-tv: https://github.com/GuillaumeSmaha/message_queue (2 files)
I found a way to fix it by using `git config --global`: https://github.com/GuillaumeSmaha/buildroot-nc4/commit/66cbde348063e1e2627dd660816311946a7d9b4c
I am not very happy with the solution because using `--global` is not the best.
I tried with these solution but it doesn't work
```
define MOONLIGHT_TV_PATCH_SUBMODULE
	mkdir -p $(MOONLIGHT_TV_DL_DIR)/git
	cd $(MOONLIGHT_TV_DL_DIR)/git ; git init ; git config url."https://github.com/GuillaumeSmaha/message_queue".insteadOf "https://github.com/LnxPrgr3/message_queue"
endef
```
It doesn't work because the next call to `git init` will erase the config.

```
MOONLIGHT_TV_GIT_SUBMODULES = NO
define MOONLIGHT_TV_PATCH_SUBMODULE
	cd $(MOONLIGHT_TV_DL_DIR)/git ; git config url."https://github.com/GuillaumeSmaha/message_queue".insteadOf "https://github.com/LnxPrgr3/message_queue" ; git submodule update --init
endef
MOONLIGHT_TV_POST_DOWNLOAD_HOOKS += MOONLIGHT_TV_PATCH_SUBMODULE
```
It doesn't work too because the tar file is already created and the call to `git submodule update --init` is useless

Another solution could be to duplicate moonlight-tv repositories and create new version `1.3.2` with a change to the submodule configuration.