### PR TITLE
configure ncurses to install libtinfo

### DIFF
--- a/package/ncurses/ncurses.mk
+++ b/package/ncurses/ncurses.mk
@@ -156,6 +156,11 @@ NCURSES_POST_INSTALL_STAGING_HOOKS += NCURSES_LINK_STAGING_PC
 
 endif # BR2_PACKAGE_NCURSES_WCHAR
 
+ifeq ($(BR2_PACKAGE_LGTV),y)
+# webOS has libtinfo
+NCURSES_CONF_OPTS += --with-termlib=tinfo
+endif
+
 ifneq ($(BR2_ENABLE_DEBUG),y)
 NCURSES_CONF_OPTS += --without-debug
 endif


### PR DESCRIPTION
On webOS, ncurses is split into libncursesw and libtinfo. This has been verified on webOS 6 and 7, where the actual sonames are libncursesw.so.5 and libtinfo.so.5.