### PR TITLE
fix statserial build with separate libtinfo

### DIFF
--- a/package/statserial/statserial.mk
+++ b/package/statserial/statserial.mk
@@ -18,4 +18,11 @@ define STATSERIAL_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/statserial $(TARGET_DIR)/usr/bin/statserial
 endef
 
+ifeq ($(BR2_PACKAGE_LGTV),y)
+define STATSERIAL_LGTV_USE_LIBTINFO
+	$(SED) 's:\s-lncurses\>:& -ltinfo:' $(@D)/Makefile
+endef
+STATSERIAL_POST_PATCH_HOOKS += STATSERIAL_LGTV_USE_LIBTINFO
+endif
+
 $(eval $(generic-package))


### PR DESCRIPTION
Splitting out libtinfo from ncurses caused the statserial build to fail due to missing symbols. This change makes it also link against libtinfo when BR2_PACKAGE_LGTV is enabled.