### PR TITLE
Use ncurses ABI 5

### DIFF
--- a/package/ncurses/ncurses.mk
+++ b/package/ncurses/ncurses.mk
@@ -157,8 +157,9 @@ NCURSES_POST_INSTALL_STAGING_HOOKS += NCURSES_LINK_STAGING_PC
 endif # BR2_PACKAGE_NCURSES_WCHAR
 
 ifeq ($(BR2_PACKAGE_LGTV),y)
-# webOS has libtinfo
-NCURSES_CONF_OPTS += --with-termlib=tinfo
+# webOS has libtinfo and ABI version 5
+NCURSES_CONF_OPTS += --with-termlib=tinfo --with-abi-version=5
+NCURSES_CONFIG_SCRIPTS = ncurses$(NCURSES_LIB_SUFFIX)5-config
 endif
 
 ifneq ($(BR2_ENABLE_DEBUG),y)


### PR DESCRIPTION
Use ABI version 5 on target (but not host) ncurses. This improves compatibility with webOS, as ncurses has the soname libncurses.so.5 on every webOS version so far (from 1.2.0 to 8.0.0).