### PR TITLE
Enable bzip2 (libbz2)

### DIFF
--- a/configs/webos_tv_defconfig
+++ b/configs/webos_tv_defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -g48f264737c Configuration
+# Buildroot -g7989555c69-dirty Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -655,7 +655,7 @@ BR2_PACKAGE_PULSEAUDIO=y
 # Compressors and decompressors
 #
 # BR2_PACKAGE_BROTLI is not set
-# BR2_PACKAGE_BZIP2 is not set
+BR2_PACKAGE_BZIP2=y
 # BR2_PACKAGE_LRZIP is not set
 # BR2_PACKAGE_LZIP is not set
 # BR2_PACKAGE_LZOP is not set

--- a/package/bzip2/bzip2.mk
+++ b/package/bzip2/bzip2.mk
@@ -66,5 +66,13 @@ define HOST_BZIP2_INSTALL_CMDS
 		$(MAKE) -f Makefile-libbz2_so PREFIX=$(HOST_DIR) -C $(@D) install
 endef
 
+define BZIP2_APPLY_WEBOS_PATCHES
+	$(APPLY_PATCHES) $(@D) package/bzip2/webos \*.patch
+endef
+
+ifeq ($(BR2_PACKAGE_LGTV),y)
+BZIP2_POST_PATCH_HOOKS += BZIP2_APPLY_WEBOS_PATCHES
+endif
+
 $(eval $(generic-package))
 $(eval $(host-generic-package))

--- a/package/bzip2/webos/bzip2-1.0.8-fix-soname.patch
+++ b/package/bzip2/webos/bzip2-1.0.8-fix-soname.patch
@@ -1,0 +1,31 @@
+OpenEmbedded modifies the bzip2 build scripts to use libtool, resulting in a
+soname of libbz2.so.1.
+
+Prior to webOS 4, the soname was libbz2.so.0. It's ABI-compatible though,
+since it's actually the same version.
+
+For more information, see:
+https://www.openembedded.org/pipermail/openembedded-core/2016-April/238341.html
+
+--- bzip2-1.0.8/Makefile-libbz2_so.orig	2023-05-23 14:14:17.890837755 -0400
++++ bzip2-1.0.8/Makefile-libbz2_so	2023-05-23 14:14:43.858329522 -0400
+@@ -34,16 +34,16 @@
+       bzlib.sho
+ 
+ all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
++	$(CC) -shared -Wl,-soname,libbz2.so.1 -o libbz2.so.1.0.8 $(OBJS)
+ 	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
+ 
+ install:
+ 	install -m 0755 -D libbz2.so.1.0.8 $(PREFIX)/lib/libbz2.so.1.0.8
+ 	ln -sf libbz2.so.1.0.8 $(PREFIX)/lib/libbz2.so
+-	ln -sf libbz2.so.1.0.8 $(PREFIX)/lib/libbz2.so.1.0
++	ln -sf libbz2.so.1.0.8 $(PREFIX)/lib/libbz2.so.1
+ 
+ clean: 
+-	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1.0 bzip2-shared
++	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1 bzip2-shared
+ 
+ %.sho: %.c
+ 	$(CC) $(CFLAGS) -o $@ -c $<

--- a/package/sdl2/sdl2.mk
+++ b/package/sdl2/sdl2.mk
@@ -51,12 +51,12 @@ define SDL2_FIX_SDL2_CONFIG_CMAKE
 endef
 SDL2_POST_INSTALL_STAGING_HOOKS += SDL2_FIX_SDL2_CONFIG_CMAKE
 
-define APPLY_WEBOS_PATCHES
+define SDL2_APPLY_WEBOS_PATCHES
 	$(APPLY_PATCHES) $(@D) package/sdl2/webos \*.patch
 endef
 
 ifeq ($(BR2_PACKAGE_SDL2_WEBOS),y)
-SDL2_POST_PATCH_HOOKS += APPLY_WEBOS_PATCHES
+SDL2_POST_PATCH_HOOKS += SDL2_APPLY_WEBOS_PATCHES
 endif
 
 # We must enable static build to get compilation successful.


### PR DESCRIPTION
Includes patch to make the libbz2 soname match the one used on webOS 4+ (`libbz2.so.1`). Previous versions used `libbz2.so.0` due to a [bug in OpenEmbedded](https://www.openembedded.org/pipermail/openembedded-core/2016-April/238341.html).