### PR TITLE
toolchain-wrapper: fix executable path resolution on macOS using system call

### DIFF
--- a/toolchain/toolchain-wrapper.c
+++ b/toolchain/toolchain-wrapper.c
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
 			perror(__FILE__ ": _NSGetExecutablePath");
 			return 2;
 		}
-#elif
+#else
 		ret = readlink("/proc/self/exe", absbasedir, PATH_MAX);
 		if (ret < 0) {
 			perror(__FILE__ ": readlink");


### PR DESCRIPTION
replaced the use of /proc/self/exe with a native system call (_NSGetExecutablePath) to correctly obtain the executable path on macOS