### PR TITLE
Update libpbnjson and lemon

### DIFF
--- a/package/lemon/lemon.hash
+++ b/package/lemon/lemon.hash
@@ -1,0 +1,2 @@
+# Locally computed (downloaded from sqlite.org)
+sha256  14dc2db487e8563ce286a38949042cb1e87ca66d872d5ea43c76391004941fe2  sqlite-src-3450000.zip

--- a/package/lemon/lemon.mk
+++ b/package/lemon/lemon.mk
@@ -4,10 +4,10 @@
 #
 ################################################################################
 
-LEMON_VERSION = 3.7.9
-LEMON_TAR_VERSION = 3070900
+LEMON_VERSION = 3.45.0
+LEMON_TAR_VERSION = 3450000
 LEMON_SOURCE = sqlite-src-$(LEMON_TAR_VERSION).zip
-LEMON_SITE = https://sqlite.org/
+LEMON_SITE = https://sqlite.org/2024
 LEMON_LICENSE = Public domain
 LEMON_LICENSE_FILES = tea/license.terms
 LEMON_CPE_ID_VENDOR = sqlite

--- a/package/libpbnjson/libpbnjson.mk
+++ b/package/libpbnjson/libpbnjson.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBPBNJSON_VERSION = 19c047b28d73c50330c1c97d2fa94aa8fccebcf6
+LIBPBNJSON_VERSION = db844b635d32283d0571347186a7fc2dcbd5fa31
 LIBPBNJSON_SITE = $(call github,webosose,libpbnjson,$(LIBPBNJSON_VERSION))
 LIBPBNJSON_INSTALL_STAGING = YES
 


### PR DESCRIPTION
Lemon (running on the build system) is required to build libpbnjson. The previous version of Lemon apparently does not work on AArch64, so I updated it to 3.45.0. I also updated libpbnjson to webosose/libpbnjson@db844b6, since prior to that commit it's not compatible with Lemon 3.44+.
