### PR TITLE
Update glibc and glibc-polyfills

### DIFF
--- a/package/glibc-polyfills/glibc-polyfills.hash
+++ b/package/glibc-polyfills/glibc-polyfills.hash
@@ -1,2 +1,2 @@
-# Locally calculated (fetched from Github)
-sha256  7804bc955e45c167b5cf29a8c1e2b3c57453edd004da2db76cb52a62926fa87a  glibc-polyfills-e778cbd37d78dcbbc5808d6cd3e49611f9c57b77.tar.gz
+# Locally calculated (fetched from GitHub)
+sha256  a111a9711643526d4117a191165fa8febc3d3c678a7a3922826553a02483d51d  glibc-polyfills-cf6fa6f9b00f833a2bcc4cec12ecb3ff65ab83aa.tar.gz

--- a/package/glibc-polyfills/glibc-polyfills.mk
+++ b/package/glibc-polyfills/glibc-polyfills.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GLIBC_POLYFILLS_VERSION = e778cbd37d78dcbbc5808d6cd3e49611f9c57b77
+GLIBC_POLYFILLS_VERSION = cf6fa6f9b00f833a2bcc4cec12ecb3ff65ab83aa
 GLIBC_POLYFILLS_SITE = $(call github,smx-smx,glibc-polyfills,$(GLIBC_POLYFILLS_VERSION))
 
 GLIBC_POLYFILLS_INSTALL_STAGING = YES

--- a/package/glibc/glibc.hash
+++ b/package/glibc/glibc.hash
@@ -1,6 +1,6 @@
-# Locally calculated (fetched from Github)
+# Locally calculated (fetched from GitHub)
 sha256  51b946f6c8dddd2b0c9902f7792ecf594497da6b0cc8fb9246fa30f108cbb422  glibc-2.36-66-ga1dc0be03c9dd850b864bd7a9c03cf8e396eb7ca.tar.gz
-sha256  33fdcbc103f02ff1088f1bd3448d67885e7e4c0abf47eda53dc3bc4015111a60  glibc-ddbe4400ebed0b7fb34e989a3ac7a73a71669bf9.tar.gz
+sha256  41d3fd31821d258e8214b3b5894206681f56c6f2feb01a7bfcac092caa7743af  glibc-cc0e3d68d499414502400a589007225f03b22437.tar.gz
 
 # Hashes for license files
 sha256  8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643  COPYING

--- a/package/glibc/glibc.mk
+++ b/package/glibc/glibc.mk
@@ -18,7 +18,7 @@ else
 #   git describe --match 'glibc-*' --abbrev=40 origin/release/MAJOR.MINOR/master | cut -d '-' -f 2-
 # When updating the version, please also update localedef
 #GLIBC_VERSION = 2.35-134-gb6aade18a7e5719c942aa2da6cf3157aca993fa4
-GLIBC_VERSION = ddbe4400ebed0b7fb34e989a3ac7a73a71669bf9
+GLIBC_VERSION = cc0e3d68d499414502400a589007225f03b22437
 
 # Upstream doesn't officially provide an https download link.
 # There is one (https://sourceware.org/git/glibc.git) but it's not reliable,


### PR DESCRIPTION
These incorporate (very) rudimentary C11 support, mostly in the form of `aligned_alloc()` (including a polyfill) and `static_assert()`.

* `glibc`: openlgtv/glibc@cc0e3d6
* `glibc-polyfills`: smx-smx/glibc-polyfills@cf6fa6f