### PR TITLE
Update webOS OSE packages

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -2696,16 +2696,16 @@ menu "LGTV"
 endmenu
 
 menu "WebOS"
-	source "package/webos/Config.in"
 	source "package/cmake-modules-webos/Config.in"
 	source "package/hyperion-webos/Config.in"
-	source "package/pmloglib/Config.in"
 	source "package/libpbnjson/Config.in"
 	source "package/libwebosi18n/Config.in"
 	source "package/luna-service2/Config.in"
+	source "package/pmloglib/Config.in"
 	source "package/umediaserver/Config.in"
-	source "package/webos-wayland-extensions/Config.in"
+	source "package/webos/Config.in"
 	source "package/webos-userland/Config.in"
+	source "package/webos-wayland-extensions/Config.in"
 endmenu
 
 endmenu

--- a/package/cmake-modules-webos/cmake-modules-webos.mk
+++ b/package/cmake-modules-webos/cmake-modules-webos.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-CMAKE_MODULES_WEBOS_VERSION = c3a5d821d1723c89936eaca82dc6d15605ad45ee
+CMAKE_MODULES_WEBOS_VERSION = c16dac87aeeb36b93489b19421fb7e127b140c50
 CMAKE_MODULES_WEBOS_SITE = $(call github,webosose,cmake-modules-webos,$(CMAKE_MODULES_WEBOS_VERSION))
 CMAKE_MODULES_WEBOS_SUPPORTS_IN_SOURCE_BUILD = NO
 CMAKE_MODULES_WEBOS_INSTALL_TARGET = NO

--- a/package/libwebosi18n/libwebosi18n.mk
+++ b/package/libwebosi18n/libwebosi18n.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBWEBOSI18N_VERSION = 3e757518ad9fa280a0cb12aca8248da912052b8b
+LIBWEBOSI18N_VERSION = b3bbc727afba52fef8319e95474b47ac0d06f8e6
 LIBWEBOSI18N_SITE = $(call github,webosose,libwebosi18n,$(LIBWEBOSI18N_VERSION))
 LIBWEBOSI18N_INSTALL_STAGING = YES
 LIBWEBOSI18N_SUPPORTS_IN_SOURCE_BUILD = NO

--- a/package/luna-service2/001-build-fixes.patch
+++ b/package/luna-service2/001-build-fixes.patch
@@ -1,14 +1,3 @@
-diff -rub a/include/private/util.hpp b/include/private/util.hpp
---- a/include/private/util.hpp	2021-11-09 14:32:09.000000000 +0100
-+++ b/include/private/util.hpp	2022-01-10 22:04:29.633297794 +0100
-@@ -19,6 +19,7 @@
- 
- #include <memory>
- #include <utility>
-+#include <string>
- 
- #include <glib.h>
- 
 diff -rub a/src/ls-hubd/CMakeLists.txt b/src/ls-hubd/CMakeLists.txt
 --- a/src/ls-hubd/CMakeLists.txt	2021-11-09 14:32:09.000000000 +0100
 +++ b/src/ls-hubd/CMakeLists.txt	2022-01-10 22:04:29.641297836 +0100
@@ -39,14 +28,3 @@ diff -rub a/src/ls-hubd/hub.cpp b/src/ls-hubd/hub.cpp
  #include <utility>
  
  template <typename Arg, typename... Args>
-diff -rub a/src/ls-hubd/hub_service.hpp b/src/ls-hubd/hub_service.hpp
---- a/src/ls-hubd/hub_service.hpp	2021-11-09 14:32:09.000000000 +0100
-+++ b/src/ls-hubd/hub_service.hpp	2022-01-10 22:04:29.641297836 +0100
-@@ -17,6 +17,7 @@
- #ifndef _HUB_SERVICE_HPP_
- #define _HUB_SERVICE_HPP_
- 
-+#include <string>
- #include <set>
- #include <memory>
- #include <unordered_map>

--- a/package/luna-service2/luna-service2.mk
+++ b/package/luna-service2/luna-service2.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LUNA_SERVICE2_VERSION = e9473aa78576d8a772a64859bb321bc429977810
+LUNA_SERVICE2_VERSION = 5d80c2779b2867f5c999d931510a83b7ec61bee1
 LUNA_SERVICE2_SITE = $(call github,webosose,luna-service2,$(LUNA_SERVICE2_VERSION))
 LUNA_SERVICE2_INSTALL_STAGING = YES
 LUNA_SERVICE2_SUPPORTS_IN_SOURCE_BUILD = NO

--- a/package/pmloglib/pmloglib.mk
+++ b/package/pmloglib/pmloglib.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PMLOGLIB_VERSION = 5a26755c09cd9d0355ec2907ded4078d00bd38c1
+PMLOGLIB_VERSION = c07d8b3232739adcefe1f667062f9de82253f3af
 PMLOGLIB_SITE = $(call github,webosose,pmloglib,$(PMLOGLIB_VERSION))
 PMLOGLIB_INSTALL_STAGING = YES
 PMLOGLIB_SUPPORTS_IN_SOURCE_BUILD = NO

--- a/package/webos-wayland-extensions/webos-wayland-extensions.mk
+++ b/package/webos-wayland-extensions/webos-wayland-extensions.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WEBOS_WAYLAND_EXTENSIONS_VERSION = 715829259cfb061ddcb5e16efa2a420e99af57e8
+WEBOS_WAYLAND_EXTENSIONS_VERSION = bc33a88c5dcf60cff7cbe998a41ca2404358a5ed
 WEBOS_WAYLAND_EXTENSIONS_SITE = $(call github,webosose,webos-wayland-extensions,$(WEBOS_WAYLAND_EXTENSIONS_VERSION))
 
 WEBOS_WAYLAND_EXTENSIONS_INSTALL_STAGING = YES


### PR DESCRIPTION
Updated several webOS OSE packages:

* webosose/luna-service2@5d80c27
* webosose/libwebosi18n@b3bbc72
* webosose/cmake-modules-webos@c16dac8
* webosose/pmloglib@c07d8b3
* webosose/webos-wayland-extensions@bc33a88

This may theoretically move them slightly further away from what's actually shipped in webOS TV, but the changes are pretty small. I was able to remove part of a `luna-service2` patch due to upstream fixes.