### PR TITLE
package/boost: update download url

### DIFF
--- a/package/boost/boost.mk
+++ b/package/boost/boost.mk
@@ -6,7 +6,7 @@
 
 BOOST_VERSION = 1.81.0
 BOOST_SOURCE = boost_$(subst .,_,$(BOOST_VERSION)).tar.bz2
-BOOST_SITE = https://boostorg.jfrog.io/artifactory/main/release/$(BOOST_VERSION)/source
+BOOST_SITE = https://archives.boost.io/release/$(BOOST_VERSION)/source
 BOOST_INSTALL_STAGING = YES
 BOOST_LICENSE = BSL-1.0
 BOOST_LICENSE_FILES = LICENSE_1_0.txt


### PR DESCRIPTION
boost moved its package hosting from jfrog to their own url provided by the C++ Alliance. According to [0] the old urls might cease to exist after December 2024.

[0] https://lists.boost.org/Archives/boost/2024/05/256914.php