### PR TITLE
Update host wayland only to v1.23.1 as per upstream buildroot

### DIFF
--- a/package/wayland/wayland.hash
+++ b/package/wayland/wayland.hash
@@ -2,3 +2,6 @@
 sha256  9540925f7928becfdf5e3b84c70757f6589bf1ceef09bea78784d8e4772c0db0	wayland-1.11.0.tar.xz
 # From https://lists.freedesktop.org/archives/wayland-devel/2018-April/037767.html
 sha256	eb3fbebb8559d56a80ad3753ec3db800f587329067962dbf65e14488b4b7aeb0	wayland-1.15.0.tar.xz
+# From https://lists.freedesktop.org/archives/wayland-devel/2024-August/043760.html
+sha256  864fb2a8399e2d0ec39d56e9d9b753c093775beadc6022ce81f441929a81e5ed  	wayland-1.23.1.tar.xz
+sha512  818eda003e3f7aa15690eedb1ff227a6056b2ce54bf23d45ffe573dc40a914623c5a1358218b59444dcdc483db0503324f0d27091d0ea954412a8b290de5f50a  wayland-1.23.1.tar.xz

--- a/package/wayland/wayland.mk
+++ b/package/wayland/wayland.mk
@@ -12,13 +12,14 @@ WAYLAND_LICENSE_FILES = COPYING
 WAYLAND_INSTALL_STAGING = YES
 WAYLAND_DEPENDENCIES = host-pkgconf host-wayland expat libffi libxml2
 
-HOST_WAYLAND_VERSION = 1.15.0
+HOST_WAYLAND_VERSION = 1.23.1
 HOST_WAYLAND_SITE = http://wayland.freedesktop.org/releases
 HOST_WAYLAND_SOURCE = wayland-$(HOST_WAYLAND_VERSION).tar.xz
 HOST_WAYLAND_DEPENDENCIES = host-pkgconf host-expat host-libffi host-libxml2
 
 # wayland-scanner is only needed for building, not on the target
 WAYLAND_CONF_OPTS = --disable-scanner --with-host-scanner
+HOST_WAYLAND_CONF_OPTS = -Dtests=false -Ddocumentation=false
 
 # Remove the DTD from the target, it's not needed at runtime
 define WAYLAND_TARGET_CLEANUP
@@ -27,4 +28,4 @@ endef
 WAYLAND_POST_INSTALL_TARGET_HOOKS += WAYLAND_TARGET_CLEANUP
 
 $(eval $(autotools-package))
-$(eval $(host-autotools-package))
+$(eval $(host-meson-package))


### PR DESCRIPTION
Update the host wayland package that contains wayland-scanner >= 1.20 as required by some dependencies now. The target wayland is kept at the same version for compatibility.