### PR TITLE
Add pmloglib patch that allows us to capture logs without needing root

### DIFF
--- a/package/pmloglib/0001-pmloglib_3.3.0-verbose.patch
+++ b/package/pmloglib/0001-pmloglib_3.3.0-verbose.patch
@@ -1,0 +1,58 @@
+diff --git a/src/PmLogLib.c b/src/PmLogLib.c
+index 6f03b24..27ea9e8 100644
+--- a/src/PmLogLib.c
++++ b/src/PmLogLib.c
+@@ -72,8 +72,8 @@ static PmLogGlobals defaultSet =
+     {
+        .info =
+        {
+-           .enabledLevel = kPmLogLevel_Info,
+-           .flags = 0
++           .enabledLevel = kPmLogLevel_Debug,
++           .flags = kPmLogFlag_LogToConsole
+        },
+        .component = kPmLogGlobalContextName
+     }
+@@ -109,8 +109,8 @@ pid_t gettid(void)
+ #define LOG_LEVEL_TAG       "level"
+ 
+ #define BUFFER_LEN 1024
+-#define CONFIG_DIR WEBOS_INSTALL_SYSCONFDIR "/pmlog.d"
+-#define OVERRIDES_CONF WEBOS_INSTALL_PREFERENCESDIR "/pmloglib/overrides.conf"
++#define CONFIG_DIR WEBOS_INSTALL_DEVELOPERDIR "/temp" WEBOS_INSTALL_SYSCONFDIR "/pmlog.d"
++#define OVERRIDES_CONF WEBOS_INSTALL_DEVELOPERDIR "/temp" WEBOS_INSTALL_PREFERENCESDIR "/pmloglib/overrides.conf"
+ #define MSGID_LEN 32
+ #define PIDSTR_LEN 32
+ 
+@@ -158,22 +158,25 @@ void CallSysLog(const char *context, const int level, const char* pidtid, const
+      ***********************************************************************/
+     #define DbgPrint(...) \
+         {                                                                           \
+-            fprintf(stdout, COMPONENT_PREFIX __VA_ARGS__);                          \
+-            CallSysLog(COMPONENT_PREFIX, "[]", __VA_ARGS__)                         \
++            fprintf(stdout, COMPONENT_PREFIX " ");                                  \
++            fprintf(stdout, __VA_ARGS__);                                           \
++            CallSysLog(COMPONENT_PREFIX, LOG_DEBUG, "[]", __VA_ARGS__);             \
+         }
+ 
+     #define ErrPrint(context, pidtid, ...) \
+         {                                                                           \
+-            fprintf(stderr, context __VA_ARGS__);                                   \
++            fprintf(stderr, "%s ", context);                                        \
++            fprintf(stderr, __VA_ARGS__);                                           \
+             fprintf(stderr, "\n");                                                  \
+-            CallSysLog(context, pidtid, __VA_ARGS__);                               \
++            CallSysLog(context, LOG_ERR, pidtid, __VA_ARGS__);                      \
+         }
+ 
+     #define WarnPrint(context, pidtid, ...) \
+         {                                                                           \
+-            fprintf(stderr, context __VA_ARGS__);                                   \
++            fprintf(stderr, "%s ", context);                                        \
++            fprintf(stderr, __VA_ARGS__);                                           \
+             fprintf(stderr, "\n");                                                  \
+-            CallSysLog(context, pidtid, __VA_ARGS__);                               \
++            CallSysLog(context, LOG_WARNING, pidtid, __VA_ARGS__);                  \
+         }
+ #else
+     /***********************************************************************


### PR DESCRIPTION
This was taken from the meta-lg-webos-ndk repo. Still works on buildroot-nc4.

path has been updated /media/developer/temp (which is writeable)

To use this: place the pmloglib.so in the a lib path. Has no affect on end users as this library is not bundled with our apps.
