### PR TITLE
Add missing HWCAP/HWCAP2 defines and INPUT_PROP_ACCELEROMETER etc

### DIFF
--- a/package/linux-headers/3.10.19/0001-unifdef-constexpr.patch
+++ b/package/linux-headers/3.10.19/0001-unifdef-constexpr.patch
@@ -1,0 +1,44 @@
+diff --git a/scripts/unifdef.c b/scripts/unifdef.c
+index 7493c0ee51cc..2030bfa4171c 100644
+--- a/scripts/unifdef.c
++++ b/scripts/unifdef.c
+@@ -203,7 +203,7 @@ static int              depth;			/* current #if nesting */
+ static int              delcount;		/* count of deleted lines */
+ static unsigned         blankcount;		/* count of blank lines */
+ static unsigned         blankmax;		/* maximum recent blankcount */
+-static bool             constexpr;		/* constant #if expression */
++static bool             constexpression;	/* constant #if expression */
+ static bool             zerosyms = true;	/* to format symdepth output */
+ static bool             firstsym;		/* ditto */
+ 
+@@ -877,7 +877,7 @@ eval_unary(const struct ops *ops, int *valp, const char **cpp)
+ 		cp = skipcomment(cp);
+ 		if (defparen && *cp++ != ')')
+ 			return (LT_ERROR);
+-		constexpr = false;
++		constexpression = false;
+ 	} else if (!endsym(*cp)) {
+ 		debug("eval%d symbol", ops - eval_ops);
+ 		sym = findsym(cp);
+@@ -895,7 +895,7 @@ eval_unary(const struct ops *ops, int *valp, const char **cpp)
+ 			lt = *valp ? LT_TRUE : LT_FALSE;
+ 			cp = skipargs(cp);
+ 		}
+-		constexpr = false;
++		constexpression = false;
+ 	} else {
+ 		debug("eval%d bad expr", ops - eval_ops);
+ 		return (LT_ERROR);
+@@ -955,10 +955,10 @@ ifeval(const char **cpp)
+ 	int val = 0;
+ 
+ 	debug("eval %s", *cpp);
+-	constexpr = killconsts ? false : true;
++	constexpression = killconsts ? false : true;
+ 	ret = eval_table(eval_ops, &val, cpp);
+ 	debug("eval = %d", val);
+-	return (constexpr ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
++	return (constexpression ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
+ }
+ 
+ /*

--- a/package/linux-headers/3.10.19/0002-arm64-hwcap.patch
+++ b/package/linux-headers/3.10.19/0002-arm64-hwcap.patch
@@ -1,0 +1,144 @@
+diff --git a/arch/arm64/include/uapi/asm/hwcap.h b/arch/arm64/include/uapi/asm/hwcap.h
+index eea497578b87..575564ecdb0b 100644
+--- a/arch/arm64/include/uapi/asm/hwcap.h
++++ b/arch/arm64/include/uapi/asm/hwcap.h
+@@ -1,3 +1,4 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+ /*
+  * Copyright (C) 2012 ARM Ltd.
+  *
+@@ -17,10 +18,133 @@
+ #define _UAPI__ASM_HWCAP_H
+ 
+ /*
+- * HWCAP flags - for elf_hwcap (in kernel) and AT_HWCAP
++ * HWCAP flags - for AT_HWCAP
++ *
++ * Bits 62 and 63 are reserved for use by libc.
++ * Bits 33-61 are unallocated for potential use by libc.
+  */
+ #define HWCAP_FP		(1 << 0)
+ #define HWCAP_ASIMD		(1 << 1)
++#define HWCAP_EVTSTRM		(1 << 2)
++#define HWCAP_AES		(1 << 3)
++#define HWCAP_PMULL		(1 << 4)
++#define HWCAP_SHA1		(1 << 5)
++#define HWCAP_SHA2		(1 << 6)
++#define HWCAP_CRC32		(1 << 7)
++#define HWCAP_ATOMICS		(1 << 8)
++#define HWCAP_FPHP		(1 << 9)
++#define HWCAP_ASIMDHP		(1 << 10)
++#define HWCAP_CPUID		(1 << 11)
++#define HWCAP_ASIMDRDM		(1 << 12)
++#define HWCAP_JSCVT		(1 << 13)
++#define HWCAP_FCMA		(1 << 14)
++#define HWCAP_LRCPC		(1 << 15)
++#define HWCAP_DCPOP		(1 << 16)
++#define HWCAP_SHA3		(1 << 17)
++#define HWCAP_SM3		(1 << 18)
++#define HWCAP_SM4		(1 << 19)
++#define HWCAP_ASIMDDP		(1 << 20)
++#define HWCAP_SHA512		(1 << 21)
++#define HWCAP_SVE		(1 << 22)
++#define HWCAP_ASIMDFHM		(1 << 23)
++#define HWCAP_DIT		(1 << 24)
++#define HWCAP_USCAT		(1 << 25)
++#define HWCAP_ILRCPC		(1 << 26)
++#define HWCAP_FLAGM		(1 << 27)
++#define HWCAP_SSBS		(1 << 28)
++#define HWCAP_SB		(1 << 29)
++#define HWCAP_PACA		(1 << 30)
++#define HWCAP_PACG		(1UL << 31)
++#define HWCAP_GCS		(1UL << 32)
++#define HWCAP_CMPBR		(1UL << 33)
++#define HWCAP_FPRCVT		(1UL << 34)
++#define HWCAP_F8MM8		(1UL << 35)
++#define HWCAP_F8MM4		(1UL << 36)
++#define HWCAP_SVE_F16MM		(1UL << 37)
++#define HWCAP_SVE_ELTPERM	(1UL << 38)
++#define HWCAP_SVE_AES2		(1UL << 39)
++#define HWCAP_SVE_BFSCALE	(1UL << 40)
++#define HWCAP_SVE2P2		(1UL << 41)
++#define HWCAP_SME2P2		(1UL << 42)
++#define HWCAP_SME_SBITPERM	(1UL << 43)
++#define HWCAP_SME_AES		(1UL << 44)
++#define HWCAP_SME_SFEXPA	(1UL << 45)
++#define HWCAP_SME_STMOP		(1UL << 46)
++#define HWCAP_SME_SMOP4		(1UL << 47)
++
++/*
++ * HWCAP2 flags - for AT_HWCAP2
++ */
++#define HWCAP2_DCPODP		(1 << 0)
++#define HWCAP2_SVE2		(1 << 1)
++#define HWCAP2_SVEAES		(1 << 2)
++#define HWCAP2_SVEPMULL		(1 << 3)
++#define HWCAP2_SVEBITPERM	(1 << 4)
++#define HWCAP2_SVESHA3		(1 << 5)
++#define HWCAP2_SVESM4		(1 << 6)
++#define HWCAP2_FLAGM2		(1 << 7)
++#define HWCAP2_FRINT		(1 << 8)
++#define HWCAP2_SVEI8MM		(1 << 9)
++#define HWCAP2_SVEF32MM		(1 << 10)
++#define HWCAP2_SVEF64MM		(1 << 11)
++#define HWCAP2_SVEBF16		(1 << 12)
++#define HWCAP2_I8MM		(1 << 13)
++#define HWCAP2_BF16		(1 << 14)
++#define HWCAP2_DGH		(1 << 15)
++#define HWCAP2_RNG		(1 << 16)
++#define HWCAP2_BTI		(1 << 17)
++#define HWCAP2_MTE		(1 << 18)
++#define HWCAP2_ECV		(1 << 19)
++#define HWCAP2_AFP		(1 << 20)
++#define HWCAP2_RPRES		(1 << 21)
++#define HWCAP2_MTE3		(1 << 22)
++#define HWCAP2_SME		(1 << 23)
++#define HWCAP2_SME_I16I64	(1 << 24)
++#define HWCAP2_SME_F64F64	(1 << 25)
++#define HWCAP2_SME_I8I32	(1 << 26)
++#define HWCAP2_SME_F16F32	(1 << 27)
++#define HWCAP2_SME_B16F32	(1 << 28)
++#define HWCAP2_SME_F32F32	(1 << 29)
++#define HWCAP2_SME_FA64		(1 << 30)
++#define HWCAP2_WFXT		(1UL << 31)
++#define HWCAP2_EBF16		(1UL << 32)
++#define HWCAP2_SVE_EBF16	(1UL << 33)
++#define HWCAP2_CSSC		(1UL << 34)
++#define HWCAP2_RPRFM		(1UL << 35)
++#define HWCAP2_SVE2P1		(1UL << 36)
++#define HWCAP2_SME2		(1UL << 37)
++#define HWCAP2_SME2P1		(1UL << 38)
++#define HWCAP2_SME_I16I32	(1UL << 39)
++#define HWCAP2_SME_BI32I32	(1UL << 40)
++#define HWCAP2_SME_B16B16	(1UL << 41)
++#define HWCAP2_SME_F16F16	(1UL << 42)
++#define HWCAP2_MOPS		(1UL << 43)
++#define HWCAP2_HBC		(1UL << 44)
++#define HWCAP2_SVE_B16B16	(1UL << 45)
++#define HWCAP2_LRCPC3		(1UL << 46)
++#define HWCAP2_LSE128		(1UL << 47)
++#define HWCAP2_FPMR		(1UL << 48)
++#define HWCAP2_LUT		(1UL << 49)
++#define HWCAP2_FAMINMAX		(1UL << 50)
++#define HWCAP2_F8CVT		(1UL << 51)
++#define HWCAP2_F8FMA		(1UL << 52)
++#define HWCAP2_F8DP4		(1UL << 53)
++#define HWCAP2_F8DP2		(1UL << 54)
++#define HWCAP2_F8E4M3		(1UL << 55)
++#define HWCAP2_F8E5M2		(1UL << 56)
++#define HWCAP2_SME_LUTV2	(1UL << 57)
++#define HWCAP2_SME_F8F16	(1UL << 58)
++#define HWCAP2_SME_F8F32	(1UL << 59)
++#define HWCAP2_SME_SF8FMA	(1UL << 60)
++#define HWCAP2_SME_SF8DP4	(1UL << 61)
++#define HWCAP2_SME_SF8DP2	(1UL << 62)
++#define HWCAP2_POE		(1UL << 63)
+ 
++/*
++ * HWCAP3 flags - for AT_HWCAP3
++ */
++#define HWCAP3_MTE_FAR		(1UL << 0)
++#define HWCAP3_MTE_STORE_ONLY		(1UL << 1)
++#define HWCAP3_LSFE		(1UL << 2)
+ 
+ #endif /* _UAPI__ASM_HWCAP_H */

--- a/package/linux-headers/3.10.19/0003-arm64-asm-hwcap.patch
+++ b/package/linux-headers/3.10.19/0003-arm64-asm-hwcap.patch
@@ -1,0 +1,232 @@
+diff --git a/arch/arm64/include/asm/hwcap.h b/arch/arm64/include/asm/hwcap.h
+index 6d4482fa35bc..6d567265467c 100644
+--- a/arch/arm64/include/asm/hwcap.h
++++ b/arch/arm64/include/asm/hwcap.h
+@@ -1,48 +1,207 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
+ /*
+  * Copyright (C) 2012 ARM Ltd.
+- *
+- * This program is free software; you can redistribute it and/or modify
+- * it under the terms of the GNU General Public License version 2 as
+- * published by the Free Software Foundation.
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU General Public License for more details.
+- *
+- * You should have received a copy of the GNU General Public License
+- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  */
+ #ifndef __ASM_HWCAP_H
+ #define __ASM_HWCAP_H
+ 
+ #include <uapi/asm/hwcap.h>
++#include <asm/cpufeature.h>
+ 
++#define COMPAT_HWCAP_SWP	(1 << 0)
+ #define COMPAT_HWCAP_HALF	(1 << 1)
+ #define COMPAT_HWCAP_THUMB	(1 << 2)
++#define COMPAT_HWCAP_26BIT	(1 << 3)
+ #define COMPAT_HWCAP_FAST_MULT	(1 << 4)
++#define COMPAT_HWCAP_FPA	(1 << 5)
+ #define COMPAT_HWCAP_VFP	(1 << 6)
+ #define COMPAT_HWCAP_EDSP	(1 << 7)
++#define COMPAT_HWCAP_JAVA	(1 << 8)
++#define COMPAT_HWCAP_IWMMXT	(1 << 9)
++#define COMPAT_HWCAP_CRUNCH	(1 << 10) /* Obsolete */
++#define COMPAT_HWCAP_THUMBEE	(1 << 11)
+ #define COMPAT_HWCAP_NEON	(1 << 12)
+ #define COMPAT_HWCAP_VFPv3	(1 << 13)
++#define COMPAT_HWCAP_VFPV3D16	(1 << 14)
+ #define COMPAT_HWCAP_TLS	(1 << 15)
+ #define COMPAT_HWCAP_VFPv4	(1 << 16)
+ #define COMPAT_HWCAP_IDIVA	(1 << 17)
+ #define COMPAT_HWCAP_IDIVT	(1 << 18)
+ #define COMPAT_HWCAP_IDIV	(COMPAT_HWCAP_IDIVA|COMPAT_HWCAP_IDIVT)
++#define COMPAT_HWCAP_VFPD32	(1 << 19)
++#define COMPAT_HWCAP_LPAE	(1 << 20)
++#define COMPAT_HWCAP_EVTSTRM	(1 << 21)
++#define COMPAT_HWCAP_FPHP	(1 << 22)
++#define COMPAT_HWCAP_ASIMDHP	(1 << 23)
++#define COMPAT_HWCAP_ASIMDDP	(1 << 24)
++#define COMPAT_HWCAP_ASIMDFHM	(1 << 25)
++#define COMPAT_HWCAP_ASIMDBF16	(1 << 26)
++#define COMPAT_HWCAP_I8MM	(1 << 27)
++
++#define COMPAT_HWCAP2_AES	(1 << 0)
++#define COMPAT_HWCAP2_PMULL	(1 << 1)
++#define COMPAT_HWCAP2_SHA1	(1 << 2)
++#define COMPAT_HWCAP2_SHA2	(1 << 3)
++#define COMPAT_HWCAP2_CRC32	(1 << 4)
++#define COMPAT_HWCAP2_SB	(1 << 5)
++#define COMPAT_HWCAP2_SSBS	(1 << 6)
+ 
+ #ifndef __ASSEMBLY__
++#include <linux/log2.h>
++
++/*
++ * For userspace we represent hwcaps as a collection of HWCAP{,2}_x bitfields
++ * as described in uapi/asm/hwcap.h. For the kernel we represent hwcaps as
++ * natural numbers (in a single range of size MAX_CPU_FEATURES) defined here
++ * with prefix KERNEL_HWCAP_ mapped to their HWCAP{,2}_x counterpart.
++ *
++ * Hwcaps should be set and tested within the kernel via the
++ * cpu_{set,have}_named_feature(feature) where feature is the unique suffix
++ * of KERNEL_HWCAP_{feature}.
++ */
++#define __khwcap_feature(x)		const_ilog2(HWCAP_ ## x)
++#define KERNEL_HWCAP_FP			__khwcap_feature(FP)
++#define KERNEL_HWCAP_ASIMD		__khwcap_feature(ASIMD)
++#define KERNEL_HWCAP_EVTSTRM		__khwcap_feature(EVTSTRM)
++#define KERNEL_HWCAP_AES		__khwcap_feature(AES)
++#define KERNEL_HWCAP_PMULL		__khwcap_feature(PMULL)
++#define KERNEL_HWCAP_SHA1		__khwcap_feature(SHA1)
++#define KERNEL_HWCAP_SHA2		__khwcap_feature(SHA2)
++#define KERNEL_HWCAP_CRC32		__khwcap_feature(CRC32)
++#define KERNEL_HWCAP_ATOMICS		__khwcap_feature(ATOMICS)
++#define KERNEL_HWCAP_FPHP		__khwcap_feature(FPHP)
++#define KERNEL_HWCAP_ASIMDHP		__khwcap_feature(ASIMDHP)
++#define KERNEL_HWCAP_CPUID		__khwcap_feature(CPUID)
++#define KERNEL_HWCAP_ASIMDRDM		__khwcap_feature(ASIMDRDM)
++#define KERNEL_HWCAP_JSCVT		__khwcap_feature(JSCVT)
++#define KERNEL_HWCAP_FCMA		__khwcap_feature(FCMA)
++#define KERNEL_HWCAP_LRCPC		__khwcap_feature(LRCPC)
++#define KERNEL_HWCAP_DCPOP		__khwcap_feature(DCPOP)
++#define KERNEL_HWCAP_SHA3		__khwcap_feature(SHA3)
++#define KERNEL_HWCAP_SM3		__khwcap_feature(SM3)
++#define KERNEL_HWCAP_SM4		__khwcap_feature(SM4)
++#define KERNEL_HWCAP_ASIMDDP		__khwcap_feature(ASIMDDP)
++#define KERNEL_HWCAP_SHA512		__khwcap_feature(SHA512)
++#define KERNEL_HWCAP_SVE		__khwcap_feature(SVE)
++#define KERNEL_HWCAP_ASIMDFHM		__khwcap_feature(ASIMDFHM)
++#define KERNEL_HWCAP_DIT		__khwcap_feature(DIT)
++#define KERNEL_HWCAP_USCAT		__khwcap_feature(USCAT)
++#define KERNEL_HWCAP_ILRCPC		__khwcap_feature(ILRCPC)
++#define KERNEL_HWCAP_FLAGM		__khwcap_feature(FLAGM)
++#define KERNEL_HWCAP_SSBS		__khwcap_feature(SSBS)
++#define KERNEL_HWCAP_SB			__khwcap_feature(SB)
++#define KERNEL_HWCAP_PACA		__khwcap_feature(PACA)
++#define KERNEL_HWCAP_PACG		__khwcap_feature(PACG)
++#define KERNEL_HWCAP_GCS		__khwcap_feature(GCS)
++#define KERNEL_HWCAP_CMPBR		__khwcap_feature(CMPBR)
++#define KERNEL_HWCAP_FPRCVT		__khwcap_feature(FPRCVT)
++#define KERNEL_HWCAP_F8MM8		__khwcap_feature(F8MM8)
++#define KERNEL_HWCAP_F8MM4		__khwcap_feature(F8MM4)
++#define KERNEL_HWCAP_SVE_F16MM		__khwcap_feature(SVE_F16MM)
++#define KERNEL_HWCAP_SVE_ELTPERM	__khwcap_feature(SVE_ELTPERM)
++#define KERNEL_HWCAP_SVE_AES2		__khwcap_feature(SVE_AES2)
++#define KERNEL_HWCAP_SVE_BFSCALE	__khwcap_feature(SVE_BFSCALE)
++#define KERNEL_HWCAP_SVE2P2		__khwcap_feature(SVE2P2)
++#define KERNEL_HWCAP_SME2P2		__khwcap_feature(SME2P2)
++#define KERNEL_HWCAP_SME_SBITPERM	__khwcap_feature(SME_SBITPERM)
++#define KERNEL_HWCAP_SME_AES		__khwcap_feature(SME_AES)
++#define KERNEL_HWCAP_SME_SFEXPA		__khwcap_feature(SME_SFEXPA)
++#define KERNEL_HWCAP_SME_STMOP		__khwcap_feature(SME_STMOP)
++#define KERNEL_HWCAP_SME_SMOP4		__khwcap_feature(SME_SMOP4)
++
++#define __khwcap2_feature(x)		(const_ilog2(HWCAP2_ ## x) + 64)
++#define KERNEL_HWCAP_DCPODP		__khwcap2_feature(DCPODP)
++#define KERNEL_HWCAP_SVE2		__khwcap2_feature(SVE2)
++#define KERNEL_HWCAP_SVEAES		__khwcap2_feature(SVEAES)
++#define KERNEL_HWCAP_SVEPMULL		__khwcap2_feature(SVEPMULL)
++#define KERNEL_HWCAP_SVEBITPERM		__khwcap2_feature(SVEBITPERM)
++#define KERNEL_HWCAP_SVESHA3		__khwcap2_feature(SVESHA3)
++#define KERNEL_HWCAP_SVESM4		__khwcap2_feature(SVESM4)
++#define KERNEL_HWCAP_FLAGM2		__khwcap2_feature(FLAGM2)
++#define KERNEL_HWCAP_FRINT		__khwcap2_feature(FRINT)
++#define KERNEL_HWCAP_SVEI8MM		__khwcap2_feature(SVEI8MM)
++#define KERNEL_HWCAP_SVEF32MM		__khwcap2_feature(SVEF32MM)
++#define KERNEL_HWCAP_SVEF64MM		__khwcap2_feature(SVEF64MM)
++#define KERNEL_HWCAP_SVEBF16		__khwcap2_feature(SVEBF16)
++#define KERNEL_HWCAP_I8MM		__khwcap2_feature(I8MM)
++#define KERNEL_HWCAP_BF16		__khwcap2_feature(BF16)
++#define KERNEL_HWCAP_DGH		__khwcap2_feature(DGH)
++#define KERNEL_HWCAP_RNG		__khwcap2_feature(RNG)
++#define KERNEL_HWCAP_BTI		__khwcap2_feature(BTI)
++#define KERNEL_HWCAP_MTE		__khwcap2_feature(MTE)
++#define KERNEL_HWCAP_ECV		__khwcap2_feature(ECV)
++#define KERNEL_HWCAP_AFP		__khwcap2_feature(AFP)
++#define KERNEL_HWCAP_RPRES		__khwcap2_feature(RPRES)
++#define KERNEL_HWCAP_MTE3		__khwcap2_feature(MTE3)
++#define KERNEL_HWCAP_SME		__khwcap2_feature(SME)
++#define KERNEL_HWCAP_SME_I16I64		__khwcap2_feature(SME_I16I64)
++#define KERNEL_HWCAP_SME_F64F64		__khwcap2_feature(SME_F64F64)
++#define KERNEL_HWCAP_SME_I8I32		__khwcap2_feature(SME_I8I32)
++#define KERNEL_HWCAP_SME_F16F32		__khwcap2_feature(SME_F16F32)
++#define KERNEL_HWCAP_SME_B16F32		__khwcap2_feature(SME_B16F32)
++#define KERNEL_HWCAP_SME_F32F32		__khwcap2_feature(SME_F32F32)
++#define KERNEL_HWCAP_SME_FA64		__khwcap2_feature(SME_FA64)
++#define KERNEL_HWCAP_WFXT		__khwcap2_feature(WFXT)
++#define KERNEL_HWCAP_EBF16		__khwcap2_feature(EBF16)
++#define KERNEL_HWCAP_SVE_EBF16		__khwcap2_feature(SVE_EBF16)
++#define KERNEL_HWCAP_CSSC		__khwcap2_feature(CSSC)
++#define KERNEL_HWCAP_RPRFM		__khwcap2_feature(RPRFM)
++#define KERNEL_HWCAP_SVE2P1		__khwcap2_feature(SVE2P1)
++#define KERNEL_HWCAP_SME2		__khwcap2_feature(SME2)
++#define KERNEL_HWCAP_SME2P1		__khwcap2_feature(SME2P1)
++#define KERNEL_HWCAP_SME_I16I32		__khwcap2_feature(SME_I16I32)
++#define KERNEL_HWCAP_SME_BI32I32	__khwcap2_feature(SME_BI32I32)
++#define KERNEL_HWCAP_SME_B16B16		__khwcap2_feature(SME_B16B16)
++#define KERNEL_HWCAP_SME_F16F16		__khwcap2_feature(SME_F16F16)
++#define KERNEL_HWCAP_MOPS		__khwcap2_feature(MOPS)
++#define KERNEL_HWCAP_HBC		__khwcap2_feature(HBC)
++#define KERNEL_HWCAP_SVE_B16B16		__khwcap2_feature(SVE_B16B16)
++#define KERNEL_HWCAP_LRCPC3		__khwcap2_feature(LRCPC3)
++#define KERNEL_HWCAP_LSE128		__khwcap2_feature(LSE128)
++#define KERNEL_HWCAP_FPMR		__khwcap2_feature(FPMR)
++#define KERNEL_HWCAP_LUT		__khwcap2_feature(LUT)
++#define KERNEL_HWCAP_FAMINMAX		__khwcap2_feature(FAMINMAX)
++#define KERNEL_HWCAP_F8CVT		__khwcap2_feature(F8CVT)
++#define KERNEL_HWCAP_F8FMA		__khwcap2_feature(F8FMA)
++#define KERNEL_HWCAP_F8DP4		__khwcap2_feature(F8DP4)
++#define KERNEL_HWCAP_F8DP2		__khwcap2_feature(F8DP2)
++#define KERNEL_HWCAP_F8E4M3		__khwcap2_feature(F8E4M3)
++#define KERNEL_HWCAP_F8E5M2		__khwcap2_feature(F8E5M2)
++#define KERNEL_HWCAP_SME_LUTV2		__khwcap2_feature(SME_LUTV2)
++#define KERNEL_HWCAP_SME_F8F16		__khwcap2_feature(SME_F8F16)
++#define KERNEL_HWCAP_SME_F8F32		__khwcap2_feature(SME_F8F32)
++#define KERNEL_HWCAP_SME_SF8FMA		__khwcap2_feature(SME_SF8FMA)
++#define KERNEL_HWCAP_SME_SF8DP4		__khwcap2_feature(SME_SF8DP4)
++#define KERNEL_HWCAP_SME_SF8DP2		__khwcap2_feature(SME_SF8DP2)
++#define KERNEL_HWCAP_POE		__khwcap2_feature(POE)
++
++#define __khwcap3_feature(x)		(const_ilog2(HWCAP3_ ## x) + 128)
++#define KERNEL_HWCAP_MTE_FAR		__khwcap3_feature(MTE_FAR)
++#define KERNEL_HWCAP_MTE_STORE_ONLY	__khwcap3_feature(MTE_STORE_ONLY)
++#define KERNEL_HWCAP_LSFE		__khwcap3_feature(LSFE)
++
+ /*
+  * This yields a mask that user programs can use to figure out what
+  * instruction set this cpu supports.
+  */
+-#define ELF_HWCAP		(elf_hwcap)
+-#define COMPAT_ELF_HWCAP	(COMPAT_HWCAP_HALF|COMPAT_HWCAP_THUMB|\
+-				 COMPAT_HWCAP_FAST_MULT|COMPAT_HWCAP_EDSP|\
+-				 COMPAT_HWCAP_TLS|COMPAT_HWCAP_VFP|\
+-				 COMPAT_HWCAP_VFPv3|COMPAT_HWCAP_VFPv4|\
+-				 COMPAT_HWCAP_NEON|COMPAT_HWCAP_IDIV)
+-
+-extern unsigned int elf_hwcap;
++#define ELF_HWCAP		cpu_get_elf_hwcap()
++#define ELF_HWCAP2		cpu_get_elf_hwcap2()
++#define ELF_HWCAP3		cpu_get_elf_hwcap3()
++
++#ifdef CONFIG_COMPAT
++#define COMPAT_ELF_HWCAP	(compat_elf_hwcap)
++#define COMPAT_ELF_HWCAP2	(compat_elf_hwcap2)
++#define COMPAT_ELF_HWCAP3	(compat_elf_hwcap3)
++extern unsigned int compat_elf_hwcap, compat_elf_hwcap2, compat_elf_hwcap3;
++#endif
++
++enum {
++	CAP_HWCAP = 1,
++#ifdef CONFIG_COMPAT
++	CAP_COMPAT_HWCAP,
++	CAP_COMPAT_HWCAP2,
++#endif
++};
++
+ #endif
+ #endif

--- a/package/linux-headers/3.10.19/0004-arm-hwcap.patch
+++ b/package/linux-headers/3.10.19/0004-arm-hwcap.patch
@@ -1,0 +1,43 @@
+diff --git a/arch/arm/include/uapi/asm/hwcap.h b/arch/arm/include/uapi/asm/hwcap.h
+index 3688fd15a32d..6b2023e39b6f 100644
+--- a/arch/arm/include/uapi/asm/hwcap.h
++++ b/arch/arm/include/uapi/asm/hwcap.h
+@@ -1,3 +1,4 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+ #ifndef _UAPI__ASMARM_HWCAP_H
+ #define _UAPI__ASMARM_HWCAP_H
+ 
+@@ -14,7 +15,7 @@
+ #define HWCAP_EDSP	(1 << 7)
+ #define HWCAP_JAVA	(1 << 8)
+ #define HWCAP_IWMMXT	(1 << 9)
+-#define HWCAP_CRUNCH	(1 << 10)
++#define HWCAP_CRUNCH	(1 << 10)	/* Obsolete */
+ #define HWCAP_THUMBEE	(1 << 11)
+ #define HWCAP_NEON	(1 << 12)
+ #define HWCAP_VFPv3	(1 << 13)
+@@ -25,6 +26,24 @@
+ #define HWCAP_IDIVT	(1 << 18)
+ #define HWCAP_VFPD32	(1 << 19)	/* set if VFP has 32 regs (not 16) */
+ #define HWCAP_IDIV	(HWCAP_IDIVA | HWCAP_IDIVT)
++#define HWCAP_LPAE	(1 << 20)
++#define HWCAP_EVTSTRM	(1 << 21)
++#define HWCAP_FPHP	(1 << 22)
++#define HWCAP_ASIMDHP	(1 << 23)
++#define HWCAP_ASIMDDP	(1 << 24)
++#define HWCAP_ASIMDFHM	(1 << 25)
++#define HWCAP_ASIMDBF16	(1 << 26)
++#define HWCAP_I8MM	(1 << 27)
+ 
++/*
++ * HWCAP2 flags - for elf_hwcap2 (in kernel) and AT_HWCAP2
++ */
++#define HWCAP2_AES	(1 << 0)
++#define HWCAP2_PMULL	(1 << 1)
++#define HWCAP2_SHA1	(1 << 2)
++#define HWCAP2_SHA2	(1 << 3)
++#define HWCAP2_CRC32	(1 << 4)
++#define HWCAP2_SB	(1 << 5)
++#define HWCAP2_SSBS	(1 << 6)
+ 
+ #endif /* _UAPI__ASMARM_HWCAP_H */

--- a/package/linux-headers/3.10.19/0005-add-input-event-codes.patch
+++ b/package/linux-headers/3.10.19/0005-add-input-event-codes.patch
@@ -1,0 +1,1009 @@
+diff --git a/include/uapi/linux/input-event-codes.h b/include/uapi/linux/input-event-codes.h
+new file mode 100644
+index 000000000000..9cd89bcc1d9c
+--- /dev/null
++++ b/include/uapi/linux/input-event-codes.h
+@@ -0,0 +1,1003 @@
++/* SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note */
++/*
++ * Input event codes
++ *
++ *    *** IMPORTANT ***
++ * This file is not only included from C-code but also from devicetree source
++ * files. As such this file MUST only contain comments and defines.
++ *
++ * Copyright (c) 1999-2002 Vojtech Pavlik
++ * Copyright (c) 2015 Hans de Goede <hdegoede@redhat.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 as published by
++ * the Free Software Foundation.
++ */
++#ifndef _UAPI_INPUT_EVENT_CODES_H
++#define _UAPI_INPUT_EVENT_CODES_H
++
++/*
++ * Device properties and quirks
++ */
++
++#define INPUT_PROP_POINTER		0x00	/* needs a pointer */
++#define INPUT_PROP_DIRECT		0x01	/* direct input devices */
++#define INPUT_PROP_BUTTONPAD		0x02	/* has button(s) under pad */
++#define INPUT_PROP_SEMI_MT		0x03	/* touch rectangle only */
++#define INPUT_PROP_TOPBUTTONPAD		0x04	/* softbuttons at top of pad */
++#define INPUT_PROP_POINTING_STICK	0x05	/* is a pointing stick */
++#define INPUT_PROP_ACCELEROMETER	0x06	/* has accelerometer */
++#define INPUT_PROP_HAPTIC_TOUCHPAD	0x07	/* is a haptic touchpad */
++
++#define INPUT_PROP_MAX			0x1f
++#define INPUT_PROP_CNT			(INPUT_PROP_MAX + 1)
++
++/*
++ * Event types
++ */
++
++#define EV_SYN			0x00
++#define EV_KEY			0x01
++#define EV_REL			0x02
++#define EV_ABS			0x03
++#define EV_MSC			0x04
++#define EV_SW			0x05
++#define EV_LED			0x11
++#define EV_SND			0x12
++#define EV_REP			0x14
++#define EV_FF			0x15
++#define EV_PWR			0x16
++#define EV_FF_STATUS		0x17
++#define EV_MAX			0x1f
++#define EV_CNT			(EV_MAX+1)
++
++/*
++ * Synchronization events.
++ */
++
++#define SYN_REPORT		0
++#define SYN_CONFIG		1
++#define SYN_MT_REPORT		2
++#define SYN_DROPPED		3
++#define SYN_MAX			0xf
++#define SYN_CNT			(SYN_MAX+1)
++
++/*
++ * Keys and buttons
++ *
++ * Most of the keys/buttons are modeled after USB HUT 1.12
++ * (see http://www.usb.org/developers/hidpage).
++ * Abbreviations in the comments:
++ * AC - Application Control
++ * AL - Application Launch Button
++ * SC - System Control
++ */
++
++#define KEY_RESERVED		0
++#define KEY_ESC			1
++#define KEY_1			2
++#define KEY_2			3
++#define KEY_3			4
++#define KEY_4			5
++#define KEY_5			6
++#define KEY_6			7
++#define KEY_7			8
++#define KEY_8			9
++#define KEY_9			10
++#define KEY_0			11
++#define KEY_MINUS		12
++#define KEY_EQUAL		13
++#define KEY_BACKSPACE		14
++#define KEY_TAB			15
++#define KEY_Q			16
++#define KEY_W			17
++#define KEY_E			18
++#define KEY_R			19
++#define KEY_T			20
++#define KEY_Y			21
++#define KEY_U			22
++#define KEY_I			23
++#define KEY_O			24
++#define KEY_P			25
++#define KEY_LEFTBRACE		26
++#define KEY_RIGHTBRACE		27
++#define KEY_ENTER		28
++#define KEY_LEFTCTRL		29
++#define KEY_A			30
++#define KEY_S			31
++#define KEY_D			32
++#define KEY_F			33
++#define KEY_G			34
++#define KEY_H			35
++#define KEY_J			36
++#define KEY_K			37
++#define KEY_L			38
++#define KEY_SEMICOLON		39
++#define KEY_APOSTROPHE		40
++#define KEY_GRAVE		41
++#define KEY_LEFTSHIFT		42
++#define KEY_BACKSLASH		43
++#define KEY_Z			44
++#define KEY_X			45
++#define KEY_C			46
++#define KEY_V			47
++#define KEY_B			48
++#define KEY_N			49
++#define KEY_M			50
++#define KEY_COMMA		51
++#define KEY_DOT			52
++#define KEY_SLASH		53
++#define KEY_RIGHTSHIFT		54
++#define KEY_KPASTERISK		55
++#define KEY_LEFTALT		56
++#define KEY_SPACE		57
++#define KEY_CAPSLOCK		58
++#define KEY_F1			59
++#define KEY_F2			60
++#define KEY_F3			61
++#define KEY_F4			62
++#define KEY_F5			63
++#define KEY_F6			64
++#define KEY_F7			65
++#define KEY_F8			66
++#define KEY_F9			67
++#define KEY_F10			68
++#define KEY_NUMLOCK		69
++#define KEY_SCROLLLOCK		70
++#define KEY_KP7			71
++#define KEY_KP8			72
++#define KEY_KP9			73
++#define KEY_KPMINUS		74
++#define KEY_KP4			75
++#define KEY_KP5			76
++#define KEY_KP6			77
++#define KEY_KPPLUS		78
++#define KEY_KP1			79
++#define KEY_KP2			80
++#define KEY_KP3			81
++#define KEY_KP0			82
++#define KEY_KPDOT		83
++
++#define KEY_ZENKAKUHANKAKU	85
++#define KEY_102ND		86
++#define KEY_F11			87
++#define KEY_F12			88
++#define KEY_RO			89
++#define KEY_KATAKANA		90
++#define KEY_HIRAGANA		91
++#define KEY_HENKAN		92
++#define KEY_KATAKANAHIRAGANA	93
++#define KEY_MUHENKAN		94
++#define KEY_KPJPCOMMA		95
++#define KEY_KPENTER		96
++#define KEY_RIGHTCTRL		97
++#define KEY_KPSLASH		98
++#define KEY_SYSRQ		99
++#define KEY_RIGHTALT		100
++#define KEY_LINEFEED		101
++#define KEY_HOME		102
++#define KEY_UP			103
++#define KEY_PAGEUP		104
++#define KEY_LEFT		105
++#define KEY_RIGHT		106
++#define KEY_END			107
++#define KEY_DOWN		108
++#define KEY_PAGEDOWN		109
++#define KEY_INSERT		110
++#define KEY_DELETE		111
++#define KEY_MACRO		112
++#define KEY_MUTE		113
++#define KEY_VOLUMEDOWN		114
++#define KEY_VOLUMEUP		115
++#define KEY_POWER		116	/* SC System Power Down */
++#define KEY_KPEQUAL		117
++#define KEY_KPPLUSMINUS		118
++#define KEY_PAUSE		119
++#define KEY_SCALE		120	/* AL Compiz Scale (Expose) */
++
++#define KEY_KPCOMMA		121
++#define KEY_HANGEUL		122
++#define KEY_HANGUEL		KEY_HANGEUL
++#define KEY_HANJA		123
++#define KEY_YEN			124
++#define KEY_LEFTMETA		125
++#define KEY_RIGHTMETA		126
++#define KEY_COMPOSE		127
++
++#define KEY_STOP		128	/* AC Stop */
++#define KEY_AGAIN		129
++#define KEY_PROPS		130	/* AC Properties */
++#define KEY_UNDO		131	/* AC Undo */
++#define KEY_FRONT		132
++#define KEY_COPY		133	/* AC Copy */
++#define KEY_OPEN		134	/* AC Open */
++#define KEY_PASTE		135	/* AC Paste */
++#define KEY_FIND		136	/* AC Search */
++#define KEY_CUT			137	/* AC Cut */
++#define KEY_HELP		138	/* AL Integrated Help Center */
++#define KEY_MENU		139	/* Menu (show menu) */
++#define KEY_CALC		140	/* AL Calculator */
++#define KEY_SETUP		141
++#define KEY_SLEEP		142	/* SC System Sleep */
++#define KEY_WAKEUP		143	/* System Wake Up */
++#define KEY_FILE		144	/* AL Local Machine Browser */
++#define KEY_SENDFILE		145
++#define KEY_DELETEFILE		146
++#define KEY_XFER		147
++#define KEY_PROG1		148
++#define KEY_PROG2		149
++#define KEY_WWW			150	/* AL Internet Browser */
++#define KEY_MSDOS		151
++#define KEY_COFFEE		152	/* AL Terminal Lock/Screensaver */
++#define KEY_SCREENLOCK		KEY_COFFEE
++#define KEY_ROTATE_DISPLAY	153	/* Display orientation for e.g. tablets */
++#define KEY_DIRECTION		KEY_ROTATE_DISPLAY
++#define KEY_CYCLEWINDOWS	154
++#define KEY_MAIL		155
++#define KEY_BOOKMARKS		156	/* AC Bookmarks */
++#define KEY_COMPUTER		157
++#define KEY_BACK		158	/* AC Back */
++#define KEY_FORWARD		159	/* AC Forward */
++#define KEY_CLOSECD		160
++#define KEY_EJECTCD		161
++#define KEY_EJECTCLOSECD	162
++#define KEY_NEXTSONG		163
++#define KEY_PLAYPAUSE		164
++#define KEY_PREVIOUSSONG	165
++#define KEY_STOPCD		166
++#define KEY_RECORD		167
++#define KEY_REWIND		168
++#define KEY_PHONE		169	/* Media Select Telephone */
++#define KEY_ISO			170
++#define KEY_CONFIG		171	/* AL Consumer Control Configuration */
++#define KEY_HOMEPAGE		172	/* AC Home */
++#define KEY_REFRESH		173	/* AC Refresh */
++#define KEY_EXIT		174	/* AC Exit */
++#define KEY_MOVE		175
++#define KEY_EDIT		176
++#define KEY_SCROLLUP		177
++#define KEY_SCROLLDOWN		178
++#define KEY_KPLEFTPAREN		179
++#define KEY_KPRIGHTPAREN	180
++#define KEY_NEW			181	/* AC New */
++#define KEY_REDO		182	/* AC Redo/Repeat */
++
++#define KEY_F13			183
++#define KEY_F14			184
++#define KEY_F15			185
++#define KEY_F16			186
++#define KEY_F17			187
++#define KEY_F18			188
++#define KEY_F19			189
++#define KEY_F20			190
++#define KEY_F21			191
++#define KEY_F22			192
++#define KEY_F23			193
++#define KEY_F24			194
++
++#define KEY_PLAYCD		200
++#define KEY_PAUSECD		201
++#define KEY_PROG3		202
++#define KEY_PROG4		203
++#define KEY_ALL_APPLICATIONS	204	/* AC Desktop Show All Applications */
++#define KEY_DASHBOARD		KEY_ALL_APPLICATIONS
++#define KEY_SUSPEND		205
++#define KEY_CLOSE		206	/* AC Close */
++#define KEY_PLAY		207
++#define KEY_FASTFORWARD		208
++#define KEY_BASSBOOST		209
++#define KEY_PRINT		210	/* AC Print */
++#define KEY_HP			211
++#define KEY_CAMERA		212
++#define KEY_SOUND		213
++#define KEY_QUESTION		214
++#define KEY_EMAIL		215
++#define KEY_CHAT		216
++#define KEY_SEARCH		217
++#define KEY_CONNECT		218
++#define KEY_FINANCE		219	/* AL Checkbook/Finance */
++#define KEY_SPORT		220
++#define KEY_SHOP		221
++#define KEY_ALTERASE		222
++#define KEY_CANCEL		223	/* AC Cancel */
++#define KEY_BRIGHTNESSDOWN	224
++#define KEY_BRIGHTNESSUP	225
++#define KEY_MEDIA		226
++
++#define KEY_SWITCHVIDEOMODE	227	/* Cycle between available video
++					   outputs (Monitor/LCD/TV-out/etc) */
++#define KEY_KBDILLUMTOGGLE	228
++#define KEY_KBDILLUMDOWN	229
++#define KEY_KBDILLUMUP		230
++
++#define KEY_SEND		231	/* AC Send */
++#define KEY_REPLY		232	/* AC Reply */
++#define KEY_FORWARDMAIL		233	/* AC Forward Msg */
++#define KEY_SAVE		234	/* AC Save */
++#define KEY_DOCUMENTS		235
++
++#define KEY_BATTERY		236
++
++#define KEY_BLUETOOTH		237
++#define KEY_WLAN		238
++#define KEY_UWB			239
++
++#define KEY_UNKNOWN		240
++
++#define KEY_VIDEO_NEXT		241	/* drive next video source */
++#define KEY_VIDEO_PREV		242	/* drive previous video source */
++#define KEY_BRIGHTNESS_CYCLE	243	/* brightness up, after max is min */
++#define KEY_BRIGHTNESS_AUTO	244	/* Set Auto Brightness: manual
++					  brightness control is off,
++					  rely on ambient */
++#define KEY_BRIGHTNESS_ZERO	KEY_BRIGHTNESS_AUTO
++#define KEY_DISPLAY_OFF		245	/* display device to off state */
++
++#define KEY_WWAN		246	/* Wireless WAN (LTE, UMTS, GSM, etc.) */
++#define KEY_WIMAX		KEY_WWAN
++#define KEY_RFKILL		247	/* Key that controls all radios */
++
++#define KEY_MICMUTE		248	/* Mute / unmute the microphone */
++
++/* Code 255 is reserved for special needs of AT keyboard driver */
++
++#define BTN_MISC		0x100
++#define BTN_0			0x100
++#define BTN_1			0x101
++#define BTN_2			0x102
++#define BTN_3			0x103
++#define BTN_4			0x104
++#define BTN_5			0x105
++#define BTN_6			0x106
++#define BTN_7			0x107
++#define BTN_8			0x108
++#define BTN_9			0x109
++
++#define BTN_MOUSE		0x110
++#define BTN_LEFT		0x110
++#define BTN_RIGHT		0x111
++#define BTN_MIDDLE		0x112
++#define BTN_SIDE		0x113
++#define BTN_EXTRA		0x114
++#define BTN_FORWARD		0x115
++#define BTN_BACK		0x116
++#define BTN_TASK		0x117
++
++#define BTN_JOYSTICK		0x120
++#define BTN_TRIGGER		0x120
++#define BTN_THUMB		0x121
++#define BTN_THUMB2		0x122
++#define BTN_TOP			0x123
++#define BTN_TOP2		0x124
++#define BTN_PINKIE		0x125
++#define BTN_BASE		0x126
++#define BTN_BASE2		0x127
++#define BTN_BASE3		0x128
++#define BTN_BASE4		0x129
++#define BTN_BASE5		0x12a
++#define BTN_BASE6		0x12b
++#define BTN_DEAD		0x12f
++
++#define BTN_GAMEPAD		0x130
++#define BTN_SOUTH		0x130
++#define BTN_A			BTN_SOUTH
++#define BTN_EAST		0x131
++#define BTN_B			BTN_EAST
++#define BTN_C			0x132
++#define BTN_NORTH		0x133
++#define BTN_X			BTN_NORTH
++#define BTN_WEST		0x134
++#define BTN_Y			BTN_WEST
++#define BTN_Z			0x135
++#define BTN_TL			0x136
++#define BTN_TR			0x137
++#define BTN_TL2			0x138
++#define BTN_TR2			0x139
++#define BTN_SELECT		0x13a
++#define BTN_START		0x13b
++#define BTN_MODE		0x13c
++#define BTN_THUMBL		0x13d
++#define BTN_THUMBR		0x13e
++
++#define BTN_DIGI		0x140
++#define BTN_TOOL_PEN		0x140
++#define BTN_TOOL_RUBBER		0x141
++#define BTN_TOOL_BRUSH		0x142
++#define BTN_TOOL_PENCIL		0x143
++#define BTN_TOOL_AIRBRUSH	0x144
++#define BTN_TOOL_FINGER		0x145
++#define BTN_TOOL_MOUSE		0x146
++#define BTN_TOOL_LENS		0x147
++#define BTN_TOOL_QUINTTAP	0x148	/* Five fingers on trackpad */
++#define BTN_STYLUS3		0x149
++#define BTN_TOUCH		0x14a
++#define BTN_STYLUS		0x14b
++#define BTN_STYLUS2		0x14c
++#define BTN_TOOL_DOUBLETAP	0x14d
++#define BTN_TOOL_TRIPLETAP	0x14e
++#define BTN_TOOL_QUADTAP	0x14f	/* Four fingers on trackpad */
++
++#define BTN_WHEEL		0x150
++#define BTN_GEAR_DOWN		0x150
++#define BTN_GEAR_UP		0x151
++
++#define KEY_OK			0x160
++#define KEY_SELECT		0x161
++#define KEY_GOTO		0x162
++#define KEY_CLEAR		0x163
++#define KEY_POWER2		0x164
++#define KEY_OPTION		0x165
++#define KEY_INFO		0x166	/* AL OEM Features/Tips/Tutorial */
++#define KEY_TIME		0x167
++#define KEY_VENDOR		0x168
++#define KEY_ARCHIVE		0x169
++#define KEY_PROGRAM		0x16a	/* Media Select Program Guide */
++#define KEY_CHANNEL		0x16b
++#define KEY_FAVORITES		0x16c
++#define KEY_EPG			0x16d
++#define KEY_PVR			0x16e	/* Media Select Home */
++#define KEY_MHP			0x16f
++#define KEY_LANGUAGE		0x170
++#define KEY_TITLE		0x171
++#define KEY_SUBTITLE		0x172
++#define KEY_ANGLE		0x173
++#define KEY_FULL_SCREEN		0x174	/* AC View Toggle */
++#define KEY_ZOOM		KEY_FULL_SCREEN
++#define KEY_MODE		0x175
++#define KEY_KEYBOARD		0x176
++#define KEY_ASPECT_RATIO	0x177	/* HUTRR37: Aspect */
++#define KEY_SCREEN		KEY_ASPECT_RATIO
++#define KEY_PC			0x178	/* Media Select Computer */
++#define KEY_TV			0x179	/* Media Select TV */
++#define KEY_TV2			0x17a	/* Media Select Cable */
++#define KEY_VCR			0x17b	/* Media Select VCR */
++#define KEY_VCR2		0x17c	/* VCR Plus */
++#define KEY_SAT			0x17d	/* Media Select Satellite */
++#define KEY_SAT2		0x17e
++#define KEY_CD			0x17f	/* Media Select CD */
++#define KEY_TAPE		0x180	/* Media Select Tape */
++#define KEY_RADIO		0x181
++#define KEY_TUNER		0x182	/* Media Select Tuner */
++#define KEY_PLAYER		0x183
++#define KEY_TEXT		0x184
++#define KEY_DVD			0x185	/* Media Select DVD */
++#define KEY_AUX			0x186
++#define KEY_MP3			0x187
++#define KEY_AUDIO		0x188	/* AL Audio Browser */
++#define KEY_VIDEO		0x189	/* AL Movie Browser */
++#define KEY_DIRECTORY		0x18a
++#define KEY_LIST		0x18b
++#define KEY_MEMO		0x18c	/* Media Select Messages */
++#define KEY_CALENDAR		0x18d
++#define KEY_RED			0x18e
++#define KEY_GREEN		0x18f
++#define KEY_YELLOW		0x190
++#define KEY_BLUE		0x191
++#define KEY_CHANNELUP		0x192	/* Channel Increment */
++#define KEY_CHANNELDOWN		0x193	/* Channel Decrement */
++#define KEY_FIRST		0x194
++#define KEY_LAST		0x195	/* Recall Last */
++#define KEY_AB			0x196
++#define KEY_NEXT		0x197
++#define KEY_RESTART		0x198
++#define KEY_SLOW		0x199
++#define KEY_SHUFFLE		0x19a
++#define KEY_BREAK		0x19b
++#define KEY_PREVIOUS		0x19c
++#define KEY_DIGITS		0x19d
++#define KEY_TEEN		0x19e
++#define KEY_TWEN		0x19f
++#define KEY_VIDEOPHONE		0x1a0	/* Media Select Video Phone */
++#define KEY_GAMES		0x1a1	/* Media Select Games */
++#define KEY_ZOOMIN		0x1a2	/* AC Zoom In */
++#define KEY_ZOOMOUT		0x1a3	/* AC Zoom Out */
++#define KEY_ZOOMRESET		0x1a4	/* AC Zoom */
++#define KEY_WORDPROCESSOR	0x1a5	/* AL Word Processor */
++#define KEY_EDITOR		0x1a6	/* AL Text Editor */
++#define KEY_SPREADSHEET		0x1a7	/* AL Spreadsheet */
++#define KEY_GRAPHICSEDITOR	0x1a8	/* AL Graphics Editor */
++#define KEY_PRESENTATION	0x1a9	/* AL Presentation App */
++#define KEY_DATABASE		0x1aa	/* AL Database App */
++#define KEY_NEWS		0x1ab	/* AL Newsreader */
++#define KEY_VOICEMAIL		0x1ac	/* AL Voicemail */
++#define KEY_ADDRESSBOOK		0x1ad	/* AL Contacts/Address Book */
++#define KEY_MESSENGER		0x1ae	/* AL Instant Messaging */
++#define KEY_DISPLAYTOGGLE	0x1af	/* Turn display (LCD) on and off */
++#define KEY_BRIGHTNESS_TOGGLE	KEY_DISPLAYTOGGLE
++#define KEY_SPELLCHECK		0x1b0   /* AL Spell Check */
++#define KEY_LOGOFF		0x1b1   /* AL Logoff */
++
++#define KEY_DOLLAR		0x1b2
++#define KEY_EURO		0x1b3
++
++#define KEY_FRAMEBACK		0x1b4	/* Consumer - transport controls */
++#define KEY_FRAMEFORWARD	0x1b5
++#define KEY_CONTEXT_MENU	0x1b6	/* GenDesc - system context menu */
++#define KEY_MEDIA_REPEAT	0x1b7	/* Consumer - transport control */
++#define KEY_10CHANNELSUP	0x1b8	/* 10 channels up (10+) */
++#define KEY_10CHANNELSDOWN	0x1b9	/* 10 channels down (10-) */
++#define KEY_IMAGES		0x1ba	/* AL Image Browser */
++#define KEY_NOTIFICATION_CENTER	0x1bc	/* Show/hide the notification center */
++#define KEY_PICKUP_PHONE	0x1bd	/* Answer incoming call */
++#define KEY_HANGUP_PHONE	0x1be	/* Decline incoming call */
++#define KEY_LINK_PHONE		0x1bf   /* AL Phone Syncing */
++
++#define KEY_DEL_EOL		0x1c0
++#define KEY_DEL_EOS		0x1c1
++#define KEY_INS_LINE		0x1c2
++#define KEY_DEL_LINE		0x1c3
++
++#define KEY_FN			0x1d0
++#define KEY_FN_ESC		0x1d1
++#define KEY_FN_F1		0x1d2
++#define KEY_FN_F2		0x1d3
++#define KEY_FN_F3		0x1d4
++#define KEY_FN_F4		0x1d5
++#define KEY_FN_F5		0x1d6
++#define KEY_FN_F6		0x1d7
++#define KEY_FN_F7		0x1d8
++#define KEY_FN_F8		0x1d9
++#define KEY_FN_F9		0x1da
++#define KEY_FN_F10		0x1db
++#define KEY_FN_F11		0x1dc
++#define KEY_FN_F12		0x1dd
++#define KEY_FN_1		0x1de
++#define KEY_FN_2		0x1df
++#define KEY_FN_D		0x1e0
++#define KEY_FN_E		0x1e1
++#define KEY_FN_F		0x1e2
++#define KEY_FN_S		0x1e3
++#define KEY_FN_B		0x1e4
++#define KEY_FN_RIGHT_SHIFT	0x1e5
++
++#define KEY_BRL_DOT1		0x1f1
++#define KEY_BRL_DOT2		0x1f2
++#define KEY_BRL_DOT3		0x1f3
++#define KEY_BRL_DOT4		0x1f4
++#define KEY_BRL_DOT5		0x1f5
++#define KEY_BRL_DOT6		0x1f6
++#define KEY_BRL_DOT7		0x1f7
++#define KEY_BRL_DOT8		0x1f8
++#define KEY_BRL_DOT9		0x1f9
++#define KEY_BRL_DOT10		0x1fa
++
++#define KEY_NUMERIC_0		0x200	/* used by phones, remote controls, */
++#define KEY_NUMERIC_1		0x201	/* and other keypads */
++#define KEY_NUMERIC_2		0x202
++#define KEY_NUMERIC_3		0x203
++#define KEY_NUMERIC_4		0x204
++#define KEY_NUMERIC_5		0x205
++#define KEY_NUMERIC_6		0x206
++#define KEY_NUMERIC_7		0x207
++#define KEY_NUMERIC_8		0x208
++#define KEY_NUMERIC_9		0x209
++#define KEY_NUMERIC_STAR	0x20a
++#define KEY_NUMERIC_POUND	0x20b
++#define KEY_NUMERIC_A		0x20c	/* Phone key A - HUT Telephony 0xb9 */
++#define KEY_NUMERIC_B		0x20d
++#define KEY_NUMERIC_C		0x20e
++#define KEY_NUMERIC_D		0x20f
++
++#define KEY_CAMERA_FOCUS	0x210
++#define KEY_WPS_BUTTON		0x211	/* WiFi Protected Setup key */
++
++#define KEY_TOUCHPAD_TOGGLE	0x212	/* Request switch touchpad on or off */
++#define KEY_TOUCHPAD_ON		0x213
++#define KEY_TOUCHPAD_OFF	0x214
++
++#define KEY_CAMERA_ZOOMIN	0x215
++#define KEY_CAMERA_ZOOMOUT	0x216
++#define KEY_CAMERA_UP		0x217
++#define KEY_CAMERA_DOWN		0x218
++#define KEY_CAMERA_LEFT		0x219
++#define KEY_CAMERA_RIGHT	0x21a
++
++#define KEY_ATTENDANT_ON	0x21b
++#define KEY_ATTENDANT_OFF	0x21c
++#define KEY_ATTENDANT_TOGGLE	0x21d	/* Attendant call on or off */
++#define KEY_LIGHTS_TOGGLE	0x21e	/* Reading light on or off */
++
++#define BTN_DPAD_UP		0x220
++#define BTN_DPAD_DOWN		0x221
++#define BTN_DPAD_LEFT		0x222
++#define BTN_DPAD_RIGHT		0x223
++
++#define BTN_GRIPL		0x224
++#define BTN_GRIPR		0x225
++#define BTN_GRIPL2		0x226
++#define BTN_GRIPR2		0x227
++
++#define KEY_ALS_TOGGLE		0x230	/* Ambient light sensor */
++#define KEY_ROTATE_LOCK_TOGGLE	0x231	/* Display rotation lock */
++#define KEY_REFRESH_RATE_TOGGLE	0x232	/* Display refresh rate toggle */
++
++#define KEY_BUTTONCONFIG		0x240	/* AL Button Configuration */
++#define KEY_TASKMANAGER		0x241	/* AL Task/Project Manager */
++#define KEY_JOURNAL		0x242	/* AL Log/Journal/Timecard */
++#define KEY_CONTROLPANEL		0x243	/* AL Control Panel */
++#define KEY_APPSELECT		0x244	/* AL Select Task/Application */
++#define KEY_SCREENSAVER		0x245	/* AL Screen Saver */
++#define KEY_VOICECOMMAND		0x246	/* Listening Voice Command */
++#define KEY_ASSISTANT		0x247	/* AL Context-aware desktop assistant */
++#define KEY_KBD_LAYOUT_NEXT	0x248	/* AC Next Keyboard Layout Select */
++#define KEY_EMOJI_PICKER	0x249	/* Show/hide emoji picker (HUTRR101) */
++#define KEY_DICTATE		0x24a	/* Start or Stop Voice Dictation Session (HUTRR99) */
++#define KEY_CAMERA_ACCESS_ENABLE	0x24b	/* Enables programmatic access to camera devices. (HUTRR72) */
++#define KEY_CAMERA_ACCESS_DISABLE	0x24c	/* Disables programmatic access to camera devices. (HUTRR72) */
++#define KEY_CAMERA_ACCESS_TOGGLE	0x24d	/* Toggles the current state of the camera access control. (HUTRR72) */
++#define KEY_ACCESSIBILITY		0x24e	/* Toggles the system bound accessibility UI/command (HUTRR116) */
++#define KEY_DO_NOT_DISTURB		0x24f	/* Toggles the system-wide "Do Not Disturb" control (HUTRR94)*/
++
++#define KEY_BRIGHTNESS_MIN		0x250	/* Set Brightness to Minimum */
++#define KEY_BRIGHTNESS_MAX		0x251	/* Set Brightness to Maximum */
++
++/*
++ * Keycodes for hotkeys toggling the electronic privacy screen found on some
++ * laptops on/off. Note when the embedded-controller turns on/off the eprivacy
++ * screen itself then the state should be reported through drm connecter props:
++ * https://www.kernel.org/doc/html/latest/gpu/drm-kms.html#standard-connector-properties
++ * Except when implementing the drm connecter properties API is not possible
++ * because e.g. the firmware does not allow querying the presence and/or status
++ * of the eprivacy screen at boot.
++ */
++#define KEY_EPRIVACY_SCREEN_ON		0x252
++#define KEY_EPRIVACY_SCREEN_OFF		0x253
++
++#define KEY_KBDINPUTASSIST_PREV		0x260
++#define KEY_KBDINPUTASSIST_NEXT		0x261
++#define KEY_KBDINPUTASSIST_PREVGROUP		0x262
++#define KEY_KBDINPUTASSIST_NEXTGROUP		0x263
++#define KEY_KBDINPUTASSIST_ACCEPT		0x264
++#define KEY_KBDINPUTASSIST_CANCEL		0x265
++
++/* Diagonal movement keys */
++#define KEY_RIGHT_UP			0x266
++#define KEY_RIGHT_DOWN			0x267
++#define KEY_LEFT_UP			0x268
++#define KEY_LEFT_DOWN			0x269
++
++#define KEY_ROOT_MENU			0x26a /* Show Device's Root Menu */
++/* Show Top Menu of the Media (e.g. DVD) */
++#define KEY_MEDIA_TOP_MENU		0x26b
++#define KEY_NUMERIC_11			0x26c
++#define KEY_NUMERIC_12			0x26d
++/*
++ * Toggle Audio Description: refers to an audio service that helps blind and
++ * visually impaired consumers understand the action in a program. Note: in
++ * some countries this is referred to as "Video Description".
++ */
++#define KEY_AUDIO_DESC			0x26e
++#define KEY_3D_MODE			0x26f
++#define KEY_NEXT_FAVORITE		0x270
++#define KEY_STOP_RECORD			0x271
++#define KEY_PAUSE_RECORD		0x272
++#define KEY_VOD				0x273 /* Video on Demand */
++#define KEY_UNMUTE			0x274
++#define KEY_FASTREVERSE			0x275
++#define KEY_SLOWREVERSE			0x276
++/*
++ * Control a data application associated with the currently viewed channel,
++ * e.g. teletext or data broadcast application (MHEG, MHP, HbbTV, etc.)
++ */
++#define KEY_DATA			0x277
++#define KEY_ONSCREEN_KEYBOARD		0x278
++/* Electronic privacy screen control */
++#define KEY_PRIVACY_SCREEN_TOGGLE	0x279
++
++/* Select an area of screen to be copied */
++#define KEY_SELECTIVE_SCREENSHOT	0x27a
++
++/* Move the focus to the next or previous user controllable element within a UI container */
++#define KEY_NEXT_ELEMENT               0x27b
++#define KEY_PREVIOUS_ELEMENT           0x27c
++
++/* Toggle Autopilot engagement */
++#define KEY_AUTOPILOT_ENGAGE_TOGGLE    0x27d
++
++/* Shortcut Keys */
++#define KEY_MARK_WAYPOINT              0x27e
++#define KEY_SOS                                0x27f
++#define KEY_NAV_CHART                  0x280
++#define KEY_FISHING_CHART              0x281
++#define KEY_SINGLE_RANGE_RADAR         0x282
++#define KEY_DUAL_RANGE_RADAR           0x283
++#define KEY_RADAR_OVERLAY              0x284
++#define KEY_TRADITIONAL_SONAR          0x285
++#define KEY_CLEARVU_SONAR              0x286
++#define KEY_SIDEVU_SONAR               0x287
++#define KEY_NAV_INFO                   0x288
++#define KEY_BRIGHTNESS_MENU            0x289
++
++/*
++ * Some keyboards have keys which do not have a defined meaning, these keys
++ * are intended to be programmed / bound to macros by the user. For most
++ * keyboards with these macro-keys the key-sequence to inject, or action to
++ * take, is all handled by software on the host side. So from the kernel's
++ * point of view these are just normal keys.
++ *
++ * The KEY_MACRO# codes below are intended for such keys, which may be labeled
++ * e.g. G1-G18, or S1 - S30. The KEY_MACRO# codes MUST NOT be used for keys
++ * where the marking on the key does indicate a defined meaning / purpose.
++ *
++ * The KEY_MACRO# codes MUST also NOT be used as fallback for when no existing
++ * KEY_FOO define matches the marking / purpose. In this case a new KEY_FOO
++ * define MUST be added.
++ */
++#define KEY_MACRO1			0x290
++#define KEY_MACRO2			0x291
++#define KEY_MACRO3			0x292
++#define KEY_MACRO4			0x293
++#define KEY_MACRO5			0x294
++#define KEY_MACRO6			0x295
++#define KEY_MACRO7			0x296
++#define KEY_MACRO8			0x297
++#define KEY_MACRO9			0x298
++#define KEY_MACRO10			0x299
++#define KEY_MACRO11			0x29a
++#define KEY_MACRO12			0x29b
++#define KEY_MACRO13			0x29c
++#define KEY_MACRO14			0x29d
++#define KEY_MACRO15			0x29e
++#define KEY_MACRO16			0x29f
++#define KEY_MACRO17			0x2a0
++#define KEY_MACRO18			0x2a1
++#define KEY_MACRO19			0x2a2
++#define KEY_MACRO20			0x2a3
++#define KEY_MACRO21			0x2a4
++#define KEY_MACRO22			0x2a5
++#define KEY_MACRO23			0x2a6
++#define KEY_MACRO24			0x2a7
++#define KEY_MACRO25			0x2a8
++#define KEY_MACRO26			0x2a9
++#define KEY_MACRO27			0x2aa
++#define KEY_MACRO28			0x2ab
++#define KEY_MACRO29			0x2ac
++#define KEY_MACRO30			0x2ad
++
++/*
++ * Some keyboards with the macro-keys described above have some extra keys
++ * for controlling the host-side software responsible for the macro handling:
++ * -A macro recording start/stop key. Note that not all keyboards which emit
++ *  KEY_MACRO_RECORD_START will also emit KEY_MACRO_RECORD_STOP if
++ *  KEY_MACRO_RECORD_STOP is not advertised, then KEY_MACRO_RECORD_START
++ *  should be interpreted as a recording start/stop toggle;
++ * -Keys for switching between different macro (pre)sets, either a key for
++ *  cycling through the configured presets or keys to directly select a preset.
++ */
++#define KEY_MACRO_RECORD_START		0x2b0
++#define KEY_MACRO_RECORD_STOP		0x2b1
++#define KEY_MACRO_PRESET_CYCLE		0x2b2
++#define KEY_MACRO_PRESET1		0x2b3
++#define KEY_MACRO_PRESET2		0x2b4
++#define KEY_MACRO_PRESET3		0x2b5
++
++/*
++ * Some keyboards have a buildin LCD panel where the contents are controlled
++ * by the host. Often these have a number of keys directly below the LCD
++ * intended for controlling a menu shown on the LCD. These keys often don't
++ * have any labeling so we just name them KEY_KBD_LCD_MENU#
++ */
++#define KEY_KBD_LCD_MENU1		0x2b8
++#define KEY_KBD_LCD_MENU2		0x2b9
++#define KEY_KBD_LCD_MENU3		0x2ba
++#define KEY_KBD_LCD_MENU4		0x2bb
++#define KEY_KBD_LCD_MENU5		0x2bc
++
++/* Performance Boost key (Alienware)/G-Mode key (Dell) */
++#define KEY_PERFORMANCE			0x2bd
++
++#define BTN_TRIGGER_HAPPY		0x2c0
++#define BTN_TRIGGER_HAPPY1		0x2c0
++#define BTN_TRIGGER_HAPPY2		0x2c1
++#define BTN_TRIGGER_HAPPY3		0x2c2
++#define BTN_TRIGGER_HAPPY4		0x2c3
++#define BTN_TRIGGER_HAPPY5		0x2c4
++#define BTN_TRIGGER_HAPPY6		0x2c5
++#define BTN_TRIGGER_HAPPY7		0x2c6
++#define BTN_TRIGGER_HAPPY8		0x2c7
++#define BTN_TRIGGER_HAPPY9		0x2c8
++#define BTN_TRIGGER_HAPPY10		0x2c9
++#define BTN_TRIGGER_HAPPY11		0x2ca
++#define BTN_TRIGGER_HAPPY12		0x2cb
++#define BTN_TRIGGER_HAPPY13		0x2cc
++#define BTN_TRIGGER_HAPPY14		0x2cd
++#define BTN_TRIGGER_HAPPY15		0x2ce
++#define BTN_TRIGGER_HAPPY16		0x2cf
++#define BTN_TRIGGER_HAPPY17		0x2d0
++#define BTN_TRIGGER_HAPPY18		0x2d1
++#define BTN_TRIGGER_HAPPY19		0x2d2
++#define BTN_TRIGGER_HAPPY20		0x2d3
++#define BTN_TRIGGER_HAPPY21		0x2d4
++#define BTN_TRIGGER_HAPPY22		0x2d5
++#define BTN_TRIGGER_HAPPY23		0x2d6
++#define BTN_TRIGGER_HAPPY24		0x2d7
++#define BTN_TRIGGER_HAPPY25		0x2d8
++#define BTN_TRIGGER_HAPPY26		0x2d9
++#define BTN_TRIGGER_HAPPY27		0x2da
++#define BTN_TRIGGER_HAPPY28		0x2db
++#define BTN_TRIGGER_HAPPY29		0x2dc
++#define BTN_TRIGGER_HAPPY30		0x2dd
++#define BTN_TRIGGER_HAPPY31		0x2de
++#define BTN_TRIGGER_HAPPY32		0x2df
++#define BTN_TRIGGER_HAPPY33		0x2e0
++#define BTN_TRIGGER_HAPPY34		0x2e1
++#define BTN_TRIGGER_HAPPY35		0x2e2
++#define BTN_TRIGGER_HAPPY36		0x2e3
++#define BTN_TRIGGER_HAPPY37		0x2e4
++#define BTN_TRIGGER_HAPPY38		0x2e5
++#define BTN_TRIGGER_HAPPY39		0x2e6
++#define BTN_TRIGGER_HAPPY40		0x2e7
++
++/* We avoid low common keys in module aliases so they don't get huge. */
++#define KEY_MIN_INTERESTING	KEY_MUTE
++#define KEY_MAX			0x2ff
++#define KEY_CNT			(KEY_MAX+1)
++
++/*
++ * Relative axes
++ */
++
++#define REL_X			0x00
++#define REL_Y			0x01
++#define REL_Z			0x02
++#define REL_RX			0x03
++#define REL_RY			0x04
++#define REL_RZ			0x05
++#define REL_HWHEEL		0x06
++#define REL_DIAL		0x07
++#define REL_WHEEL		0x08
++#define REL_MISC		0x09
++/*
++ * 0x0a is reserved and should not be used in input drivers.
++ * It was used by HID as REL_MISC+1 and userspace needs to detect if
++ * the next REL_* event is correct or is just REL_MISC + n.
++ * We define here REL_RESERVED so userspace can rely on it and detect
++ * the situation described above.
++ */
++#define REL_RESERVED		0x0a
++#define REL_WHEEL_HI_RES	0x0b
++#define REL_HWHEEL_HI_RES	0x0c
++#define REL_MAX			0x0f
++#define REL_CNT			(REL_MAX+1)
++
++/*
++ * Absolute axes
++ */
++
++#define ABS_X			0x00
++#define ABS_Y			0x01
++#define ABS_Z			0x02
++#define ABS_RX			0x03
++#define ABS_RY			0x04
++#define ABS_RZ			0x05
++#define ABS_THROTTLE		0x06
++#define ABS_RUDDER		0x07
++#define ABS_WHEEL		0x08
++#define ABS_GAS			0x09
++#define ABS_BRAKE		0x0a
++#define ABS_HAT0X		0x10
++#define ABS_HAT0Y		0x11
++#define ABS_HAT1X		0x12
++#define ABS_HAT1Y		0x13
++#define ABS_HAT2X		0x14
++#define ABS_HAT2Y		0x15
++#define ABS_HAT3X		0x16
++#define ABS_HAT3Y		0x17
++#define ABS_PRESSURE		0x18
++#define ABS_DISTANCE		0x19
++#define ABS_TILT_X		0x1a
++#define ABS_TILT_Y		0x1b
++#define ABS_TOOL_WIDTH		0x1c
++
++#define ABS_VOLUME		0x20
++#define ABS_PROFILE		0x21
++
++#define ABS_MISC		0x28
++
++/*
++ * 0x2e is reserved and should not be used in input drivers.
++ * It was used by HID as ABS_MISC+6 and userspace needs to detect if
++ * the next ABS_* event is correct or is just ABS_MISC + n.
++ * We define here ABS_RESERVED so userspace can rely on it and detect
++ * the situation described above.
++ */
++#define ABS_RESERVED		0x2e
++
++#define ABS_MT_SLOT		0x2f	/* MT slot being modified */
++#define ABS_MT_TOUCH_MAJOR	0x30	/* Major axis of touching ellipse */
++#define ABS_MT_TOUCH_MINOR	0x31	/* Minor axis (omit if circular) */
++#define ABS_MT_WIDTH_MAJOR	0x32	/* Major axis of approaching ellipse */
++#define ABS_MT_WIDTH_MINOR	0x33	/* Minor axis (omit if circular) */
++#define ABS_MT_ORIENTATION	0x34	/* Ellipse orientation */
++#define ABS_MT_POSITION_X	0x35	/* Center X touch position */
++#define ABS_MT_POSITION_Y	0x36	/* Center Y touch position */
++#define ABS_MT_TOOL_TYPE	0x37	/* Type of touching device */
++#define ABS_MT_BLOB_ID		0x38	/* Group a set of packets as a blob */
++#define ABS_MT_TRACKING_ID	0x39	/* Unique ID of initiated contact */
++#define ABS_MT_PRESSURE		0x3a	/* Pressure on contact area */
++#define ABS_MT_DISTANCE		0x3b	/* Contact hover distance */
++#define ABS_MT_TOOL_X		0x3c	/* Center X tool position */
++#define ABS_MT_TOOL_Y		0x3d	/* Center Y tool position */
++
++
++#define ABS_MAX			0x3f
++#define ABS_CNT			(ABS_MAX+1)
++
++/*
++ * Switch events
++ */
++
++#define SW_LID			0x00  /* set = lid shut */
++#define SW_TABLET_MODE		0x01  /* set = tablet mode */
++#define SW_HEADPHONE_INSERT	0x02  /* set = inserted */
++#define SW_RFKILL_ALL		0x03  /* rfkill master switch, type "any"
++					 set = radio enabled */
++#define SW_RADIO		SW_RFKILL_ALL	/* deprecated */
++#define SW_MICROPHONE_INSERT	0x04  /* set = inserted */
++#define SW_DOCK			0x05  /* set = plugged into dock */
++#define SW_LINEOUT_INSERT	0x06  /* set = inserted */
++#define SW_JACK_PHYSICAL_INSERT 0x07  /* set = mechanical switch set */
++#define SW_VIDEOOUT_INSERT	0x08  /* set = inserted */
++#define SW_CAMERA_LENS_COVER	0x09  /* set = lens covered */
++#define SW_KEYPAD_SLIDE		0x0a  /* set = keypad slide out */
++#define SW_FRONT_PROXIMITY	0x0b  /* set = front proximity sensor active */
++#define SW_ROTATE_LOCK		0x0c  /* set = rotate locked/disabled */
++#define SW_LINEIN_INSERT	0x0d  /* set = inserted */
++#define SW_MUTE_DEVICE		0x0e  /* set = device disabled */
++#define SW_PEN_INSERTED		0x0f  /* set = pen inserted */
++#define SW_MACHINE_COVER	0x10  /* set = cover closed */
++#define SW_USB_INSERT		0x11  /* set = USB audio device connected */
++#define SW_MAX			0x11
++#define SW_CNT			(SW_MAX+1)
++
++/*
++ * Misc events
++ */
++
++#define MSC_SERIAL		0x00
++#define MSC_PULSELED		0x01
++#define MSC_GESTURE		0x02
++#define MSC_RAW			0x03
++#define MSC_SCAN		0x04
++#define MSC_TIMESTAMP		0x05
++#define MSC_MAX			0x07
++#define MSC_CNT			(MSC_MAX+1)
++
++/*
++ * LEDs
++ */
++
++#define LED_NUML		0x00
++#define LED_CAPSL		0x01
++#define LED_SCROLLL		0x02
++#define LED_COMPOSE		0x03
++#define LED_KANA		0x04
++#define LED_SLEEP		0x05
++#define LED_SUSPEND		0x06
++#define LED_MUTE		0x07
++#define LED_MISC		0x08
++#define LED_MAIL		0x09
++#define LED_CHARGING		0x0a
++#define LED_MAX			0x0f
++#define LED_CNT			(LED_MAX+1)
++
++/*
++ * Autorepeat values
++ */
++
++#define REP_DELAY		0x00
++#define REP_PERIOD		0x01
++#define REP_MAX			0x01
++#define REP_CNT			(REP_MAX+1)
++
++/*
++ * Sounds
++ */
++
++#define SND_CLICK		0x00
++#define SND_BELL		0x01
++#define SND_TONE		0x02
++#define SND_MAX			0x07
++#define SND_CNT			(SND_MAX+1)
++
++#endif


### PR DESCRIPTION
This PR adds much needed missing defines used by a few retroarch cores for webOS

They are taken from latest linux kernel source.

Patch 0001 makes it possible to compile in the first place as constexpr is reserved and fails under GCC 15.